### PR TITLE
Add start-server script to run server with in-memory caching for REST calls

### DIFF
--- a/packages/service/README.md
+++ b/packages/service/README.md
@@ -4,9 +4,10 @@ The GraphQL server! All data is fetched from [PokeAPI](https://pokeapi.co/docs/v
 
 ## Scripts
 
-| Command      | Description                                                    |
-| ------------ | -------------------------------------------------------------- |
-| `start`      | Starts a server where we can run GraphQL server Lambda locally |
-| `test`       | Runs server integration tests with Jest                        |
-| `deploy`     | Deploys the service to AWS with Serverless Framework           |
-| `deploy-dev` | Deploys the service with the Playground enabled to AWS         |
+| Command        | Description                                                                       |
+| -------------- | --------------------------------------------------------------------------------- |
+| `start`        | Starts serverless-offline where we can run the Apollo Server Lambda locally       |
+| `start-server` | Starts Apollo Server using an actual server with in-memory caching for REST calls |
+| `test`         | Runs server integration tests with Jest                                           |
+| `deploy`       | Deploys the service to AWS with Serverless Framework                              |
+| `deploy-dev`   | Deploys the service with the Playground enabled to AWS                            |

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -4,12 +4,14 @@
   "license": "UNLICENSED",
   "scripts": {
     "start": "npx serverless offline",
+    "start-server": "webpack-cli --config ./webpack.config.server.js",
     "test": "jest",
     "deploy": "npx serverless deploy",
     "deploy-dev": "NODE_ENV=development yarn deploy"
   },
   "dependencies": {
     "apollo-datasource-rest": "^0.13.0",
+    "apollo-server": "^2.24.0",
     "apollo-server-lambda": "^2.24.0",
     "base64-url": "^2.3.3"
   },
@@ -25,7 +27,9 @@
     "serverless-plugin-typescript": "^1.1.9",
     "serverless-webpack": "^5.4.2",
     "source-map-support": "^0.5.19",
+    "start-server-nestjs-webpack-plugin": "^2.2.5",
     "ts-loader": "^9.1.1",
-    "webpack": "^5.36.2"
+    "webpack": "^5.36.2",
+    "webpack-cli": "^4.7.0"
   }
 }

--- a/packages/service/src/__tests__/__snapshots__/getPokemon.test.ts.snap
+++ b/packages/service/src/__tests__/__snapshots__/getPokemon.test.ts.snap
@@ -15,7 +15,7 @@ Object {
       "baseExperience": 64,
       "height": 7,
       "heldItems": Array [],
-      "id": "1",
+      "id": "bulbasaur",
       "moves": Array [
         Object {
           "name": "Razor Wind",

--- a/packages/service/src/__tests__/__snapshots__/listPokemon.test.ts.snap
+++ b/packages/service/src/__tests__/__snapshots__/listPokemon.test.ts.snap
@@ -9,7 +9,7 @@ Object {
           "cursor": "MA",
           "node": Object {
             "baseExperience": 64,
-            "id": "1",
+            "id": "bulbasaur",
             "name": "Bulbasaur",
             "order": 1,
             "sprites": Object {
@@ -29,7 +29,7 @@ Object {
           "cursor": "MQ",
           "node": Object {
             "baseExperience": 142,
-            "id": "2",
+            "id": "ivysaur",
             "name": "Ivysaur",
             "order": 2,
             "sprites": Object {

--- a/packages/service/src/dataSources/PokeAPI.ts
+++ b/packages/service/src/dataSources/PokeAPI.ts
@@ -16,12 +16,13 @@ export class PokeAPI extends RESTDataSource {
   }
 
   /**
-   * Hyphenated name (e.g., ho-oh) can also be used instead of id
+   * We are using name as id across the application because it is included
+   * in NamedAPIResource.
    * https://pokeapi.co/docs/v2#pokemon
    */
-  async getPokemon(idOrName: string): Promise<Pokemon> {
+  async getPokemon(id: string): Promise<Pokemon> {
     // Send a GET request to the specified endpoint
-    return this.get(`pokemon/${idOrName}`);
+    return this.get(`pokemon/${id}`);
   }
 
   /**
@@ -45,21 +46,21 @@ export class PokeAPI extends RESTDataSource {
   /**
    * https://pokeapi.co/docs/v2#pokemon-species
    */
-  async getSpecies(idOrName: string): Promise<Species> {
-    return this.get(`pokemon-species/${idOrName}`);
+  async getSpecies(id: string): Promise<Species> {
+    return this.get(`pokemon-species/${id}`);
   }
 
   /**
    * https://pokeapi.co/docs/v2#types
    */
-  async getType(idOrName: string): Promise<Type> {
-    return this.get(`type/${idOrName}`);
+  async getType(id: string): Promise<Type> {
+    return this.get(`type/${id}`);
   }
 
   /**
    * https://pokeapi.co/docs/v2#types
    */
-  async getGrowthRate(idOrName: string): Promise<GrowthRate> {
-    return this.get(`growth-rate/${idOrName}`);
+  async getGrowthRate(id: string): Promise<GrowthRate> {
+    return this.get(`growth-rate/${id}`);
   }
 }

--- a/packages/service/src/resolvers/growthRate.ts
+++ b/packages/service/src/resolvers/growthRate.ts
@@ -4,6 +4,7 @@ import {
   PokemonSpecies,
   PokemonSpeciesResolvers,
 } from '../types';
+import { formatName } from '../utils/string';
 
 type PokemonGrowthRateResolver = PokemonSpeciesResolvers<
   Context,
@@ -15,13 +16,13 @@ export const growthRate: PokemonGrowthRateResolver = async (
   _,
   { dataSources }: Context,
 ): Promise<PokemonGrowthRate | null> => {
-  const name = parent?.growthRate?.name;
-  if (!name) {
+  const id = parent?.growthRate?.id;
+  if (!id) {
     return null;
   }
-  return dataSources.pokeAPI.getGrowthRate(name).then((resource) => ({
-    name,
-    id: resource.id.toString(),
+  return dataSources.pokeAPI.getGrowthRate(id).then((resource) => ({
+    id,
+    name: formatName(resource.name),
     formula: resource.formula,
     levels: resource.levels,
   }));

--- a/packages/service/src/resolvers/index.ts
+++ b/packages/service/src/resolvers/index.ts
@@ -2,6 +2,7 @@ import { Resolvers } from '../types';
 import { getPokemon } from './getPokemon';
 import { growthRate } from './growthRate';
 import { listPokemon } from './listPokemon/listPokemon';
+import { pokemonNode } from './pokemonNode';
 import { species } from './species';
 
 // Provide resolver functions for your schema fields
@@ -9,6 +10,9 @@ export const resolvers: Resolvers = {
   Query: {
     getPokemon,
     listPokemon,
+  },
+  PokemonEdge: {
+    node: pokemonNode,
   },
   PokemonNode: {
     species,

--- a/packages/service/src/resolvers/listPokemon/listPokemon.ts
+++ b/packages/service/src/resolvers/listPokemon/listPokemon.ts
@@ -5,7 +5,7 @@ import {
   QueryResolvers,
 } from '../../types';
 import { fromCursor } from '../../utils/cursor';
-import { pokemonToEdge } from '../../utils/transform';
+import { resourceToEdge } from '../../utils/transform';
 import {
   createPokemonConnection,
   getFilteredSortedPokemonResources,
@@ -44,13 +44,7 @@ export const listPokemon: ListPokemonResolver = async (
   const { resources, hasPreviousPage, hasNextPage, totalCount } =
     filteredSortedResult || result;
 
-  // Retrieve the complete pokemon data for each resource and convert to edges
-  const pokemons = await Promise.all(
-    resources.map(async (resource) =>
-      dataSources.pokeAPI.getPokemon(resource.name),
-    ),
-  );
-  const edges: PokemonEdge[] = pokemons.map(pokemonToEdge(offset));
+  const edges: PokemonEdge[] = resources.map(resourceToEdge(offset));
 
   return createPokemonConnection(
     edges,

--- a/packages/service/src/resolvers/listPokemon/utils.ts
+++ b/packages/service/src/resolvers/listPokemon/utils.ts
@@ -6,12 +6,12 @@ import {
   PokemonEdge,
   PokemonFilterInput,
   PokemonSortInput,
-  Sort,
+  Sort
 } from '../../types';
 import { sortPokemonResources } from '../../utils/sort';
 import {
   speciesToPokemonResource,
-  typeToPokemonResource,
+  typeToPokemonResource
 } from '../../utils/transform';
 
 /**
@@ -74,7 +74,6 @@ export const getPokemonResources = async (
       previous,
       next,
     } = await dataSources.pokeAPI.getPokemonResourceList(first, offset);
-    console.log({ next });
 
     resources = results;
     // If we are using the paged resource list, set PageInfo flags and totalCount here

--- a/packages/service/src/resolvers/pokemonNode.ts
+++ b/packages/service/src/resolvers/pokemonNode.ts
@@ -19,9 +19,9 @@ export const pokemonNode: PokemonGrowthRateResolver = async (
   _,
   { dataSources }: Context,
 ): Promise<PokemonNode | null> => {
-  const name = parent?.node?.name;
-  if (!name) {
+  const id = parent?.node?.id;
+  if (!id) {
     return null;
   }
-  return dataSources.pokeAPI.getPokemon(name).then(pokemonToPokemonNode);
+  return dataSources.pokeAPI.getPokemon(id).then(pokemonToPokemonNode);
 };

--- a/packages/service/src/resolvers/pokemonNode.ts
+++ b/packages/service/src/resolvers/pokemonNode.ts
@@ -1,0 +1,27 @@
+import {
+  Context,
+  PokemonEdge,
+  PokemonEdgeResolvers,
+  PokemonNode,
+} from '../types';
+import { pokemonToPokemonNode } from '../utils';
+
+type PokemonGrowthRateResolver = PokemonEdgeResolvers<
+  Context,
+  PokemonEdge
+>['node'];
+
+/**
+ * Retrieves the complete pokemon node for each edge.
+ */
+export const pokemonNode: PokemonGrowthRateResolver = async (
+  parent,
+  _,
+  { dataSources }: Context,
+): Promise<PokemonNode | null> => {
+  const name = parent?.node?.name;
+  if (!name) {
+    return null;
+  }
+  return dataSources.pokeAPI.getPokemon(name).then(pokemonToPokemonNode);
+};

--- a/packages/service/src/resolvers/species.ts
+++ b/packages/service/src/resolvers/species.ts
@@ -4,6 +4,7 @@ import {
   PokemonNodeResolvers,
   PokemonSpecies,
 } from '../types';
+import { formatName } from '../utils';
 
 type PokemonSpeciesResolver = PokemonNodeResolvers<
   Context,
@@ -14,15 +15,16 @@ export const species: PokemonSpeciesResolver = async (
   _,
   { dataSources }: Context,
 ): Promise<PokemonSpecies | null> => {
-  const name = parent?.species?.name;
-  if (!name) {
+  const id = parent?.species?.id;
+  if (!id) {
     return null;
   }
-  return dataSources.pokeAPI.getSpecies(name).then((resource) => ({
-    name,
-    id: resource.id.toString(),
+  return dataSources.pokeAPI.getSpecies(id).then((resource) => ({
+    id,
+    name: formatName(resource.name),
     growthRate: {
-      name: resource.growth_rate.name,
+      // Resolved to complete resource by growthRate resolver
+      id: resource.growth_rate.name,
     },
   }));
 };

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -1,0 +1,20 @@
+import { ApolloServer } from 'apollo-server';
+import typeDefs from './typeDefs.graphql';
+import { resolvers } from './resolvers';
+import { dataSources } from './dataSources';
+
+const server = new ApolloServer({
+  typeDefs,
+  resolvers,
+  dataSources,
+  // Run Playground if development
+  ...(process.env.NODE_ENV === 'development' && {
+    playground: {
+      endpoint: '/dev/graphql',
+    },
+  }),
+});
+
+server.listen().then(({ url }) => {
+  console.log(`🚀  Server ready at ${url}`);
+});

--- a/packages/service/src/server.ts
+++ b/packages/service/src/server.ts
@@ -1,7 +1,7 @@
 import { ApolloServer } from 'apollo-server';
-import typeDefs from './typeDefs.graphql';
-import { resolvers } from './resolvers';
 import { dataSources } from './dataSources';
+import { resolvers } from './resolvers';
+import typeDefs from './typeDefs.graphql';
 
 const server = new ApolloServer({
   typeDefs,

--- a/packages/service/src/typeDefs.graphql
+++ b/packages/service/src/typeDefs.graphql
@@ -49,24 +49,24 @@ type PokemonSpecies {
 }
 
 type PokemonNode {
-  id: ID!
+  id: ID
   name: String!
-  baseExperience: Int!
-  height: Int!
-  order: Int!
-  weight: Int!
-  abilities: [Item]!
-  heldItems: [Item]!
-  moves: [Item]!
-  sprites: Sprites!
-  stats: [Stat]!
-  types: [Item]!
+  baseExperience: Int
+  height: Int
+  order: Int
+  weight: Int
+  abilities: [Item]
+  heldItems: [Item]
+  moves: [Item]
+  sprites: Sprites
+  stats: [Stat]
+  types: [Item]
   species: PokemonSpecies
 }
 
 type PokemonEdge {
   cursor: String!
-  node: PokemonNode!
+  node: PokemonNode
 }
 
 type PokemonConnection {

--- a/packages/service/src/typeDefs.graphql
+++ b/packages/service/src/typeDefs.graphql
@@ -11,10 +11,12 @@ enum Sort {
 }
 
 type Item {
+  id: ID!
   name: String!
 }
 
 type Stat {
+  id: ID!
   name: String!
   baseStat: Int!
 }
@@ -49,8 +51,9 @@ type PokemonSpecies {
 }
 
 type PokemonNode {
-  id: ID
-  name: String!
+  id: ID!
+  pokedexNumber: Int
+  name: String
   baseExperience: Int
   height: Int
   order: Int

--- a/packages/service/src/utils/transform.ts
+++ b/packages/service/src/utils/transform.ts
@@ -52,6 +52,17 @@ export const pokemonToPokemonNode = (pokemon: Pokemon): PokemonNode => ({
     })),
 });
 
+export const resourceToEdge = (offset: number) => (
+  resource: NamedAPIResource,
+  index: number,
+): PokemonEdge => ({
+  // Use index to create the cursor so that it works with filtered or sorted lists
+  cursor: toCursor(offset + index),
+  node: {
+    name: resource.name,
+  },
+});
+
 export const pokemonToEdge = (offset: number) => (
   pokemon: Pokemon,
   index: number,

--- a/packages/service/src/utils/transform.ts
+++ b/packages/service/src/utils/transform.ts
@@ -10,24 +10,30 @@ import { toCursor } from './cursor';
 import { formatName } from './string';
 
 export const pokemonToPokemonNode = (pokemon: Pokemon): PokemonNode => ({
-  id: pokemon.id.toString(),
+  // Use name as id, since this is the identifier included in NamedAPIResource
+  id: pokemon.name,
+  // Use id as pokedexNumber instead
+  pokedexNumber: pokemon.id,
   name: formatName(pokemon.name),
   order: pokemon.order,
   height: pokemon.height,
   baseExperience: pokemon.base_experience,
   weight: pokemon.weight,
   abilities: pokemon.abilities.map((resource) => ({
+    id: resource.ability.name,
     name: formatName(resource.ability.name),
   })),
   heldItems: pokemon.held_items.map((resource) => ({
+    id: resource.item.name,
     name: formatName(resource.item.name),
   })),
   moves: pokemon.moves.map((resource) => ({
+    id: resource.move.name,
     name: formatName(resource.move.name),
   })),
   // Rest of fields resolved by species resolver
   species: {
-    name: pokemon.species.name,
+    id: pokemon.species.name,
   },
   sprites: {
     frontDefault: pokemon.sprites.front_default,
@@ -40,6 +46,7 @@ export const pokemonToPokemonNode = (pokemon: Pokemon): PokemonNode => ({
     backShinyFemale: pokemon.sprites.back_shiny_female,
   },
   stats: pokemon.stats.map((resource) => ({
+    id: resource.stat.name,
     // Return all uppercase for hp
     name: resource.stat.name === 'hp' ? 'HP' : formatName(resource.stat.name),
     baseStat: resource.base_stat,
@@ -48,6 +55,7 @@ export const pokemonToPokemonNode = (pokemon: Pokemon): PokemonNode => ({
     // Sort by slot
     .sort((a, b) => a.slot - b.slot)
     .map((resource) => ({
+      id: resource.type.name,
       name: formatName(resource.type.name),
     })),
 });
@@ -59,7 +67,7 @@ export const resourceToEdge = (offset: number) => (
   // Use index to create the cursor so that it works with filtered or sorted lists
   cursor: toCursor(offset + index),
   node: {
-    name: resource.name,
+    id: resource.name,
   },
 });
 

--- a/packages/service/tsconfig.json
+++ b/packages/service/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/service/webpack.config.server.js
+++ b/packages/service/webpack.config.server.js
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const path = require('path');
+const StartServerPlugin = require('start-server-nestjs-webpack-plugin');
+
+module.exports = {
+  entry: {
+    server: './src/server.ts',
+  },
+  mode: process.env.NODE_ENV ? 'development' : 'production',
+  output: {
+    libraryTarget: 'commonjs',
+    path: path.join(__dirname, '.webpack'),
+    filename: '[name].js',
+  },
+  module: {
+    rules: [
+      // All files with a `.ts` or `.tsx` extension will be handled by `ts-loader`
+      {
+        test: /\.tsx?$/,
+        loader: 'ts-loader',
+        options: { transpileOnly: true },
+      },
+      {
+        test: /\.(graphql|gql)$/,
+        exclude: /node_modules/,
+        loader: 'graphql-tag/loader',
+      },
+    ],
+  },
+  plugins: [
+    new StartServerPlugin({ name: 'server.js', nodeArgs: ['--inspect'] }),
+  ],
+  resolve: {
+    extensions: ['.js', '.jsx', '.json', '.ts', '.tsx'],
+    // https://github.com/apollographql/apollo-server/issues/4637
+    alias: {
+      graphql$: path.resolve(__dirname, '../../node_modules/graphql/index.js'),
+    },
+  },
+  devtool: 'source-map',
+  target: 'node',
+};

--- a/packages/web/src/__fixtures__/mockedGetPokemonQuery.ts
+++ b/packages/web/src/__fixtures__/mockedGetPokemonQuery.ts
@@ -5,14 +5,15 @@ export const mockedGetPokemonQuery: MockedResponse<GetPokemonQuery> = {
   request: {
     query: GetPokemonDocument,
     variables: {
-      id: '1',
+      id: 'bulbasaur',
     },
   },
   result: {
     data: {
       getPokemon: {
         __typename: 'PokemonNode',
-        id: '1',
+        id: 'bulbasaur',
+        pokedexNumber: 1,
         name: 'Bulbasaur',
         baseExperience: 64,
         height: 7,
@@ -36,10 +37,12 @@ export const mockedGetPokemonQuery: MockedResponse<GetPokemonQuery> = {
         abilities: [
           {
             __typename: 'Item',
+            id: 'overgrow',
             name: 'Overgrow',
           },
           {
             __typename: 'Item',
+            id: 'chlorophyll',
             name: 'Chlorophyll',
           },
         ],
@@ -47,323 +50,401 @@ export const mockedGetPokemonQuery: MockedResponse<GetPokemonQuery> = {
         moves: [
           {
             __typename: 'Item',
+            id: 'razor-wind',
             name: 'Razor Wind',
           },
           {
             __typename: 'Item',
+            id: 'swords-dance',
             name: 'Swords Dance',
           },
           {
             __typename: 'Item',
+            id: 'cut',
             name: 'Cut',
           },
           {
             __typename: 'Item',
+            id: 'bind',
             name: 'Bind',
           },
           {
             __typename: 'Item',
+            id: 'vine-whip',
             name: 'Vine Whip',
           },
           {
             __typename: 'Item',
+            id: 'headbutt',
             name: 'Headbutt',
           },
           {
             __typename: 'Item',
+            id: 'tackle',
             name: 'Tackle',
           },
           {
             __typename: 'Item',
+            id: 'body-slam',
             name: 'Body Slam',
           },
           {
             __typename: 'Item',
+            id: 'take-down',
             name: 'Take Down',
           },
           {
             __typename: 'Item',
+            id: 'double-edge',
             name: 'Double Edge',
           },
           {
             __typename: 'Item',
+            id: 'growl',
             name: 'Growl',
           },
           {
             __typename: 'Item',
+            id: 'strength',
             name: 'Strength',
           },
           {
             __typename: 'Item',
+            id: 'mega-drain',
             name: 'Mega Drain',
           },
           {
             __typename: 'Item',
+            id: 'leech-seed',
             name: 'Leech Seed',
           },
           {
             __typename: 'Item',
+            id: 'growth',
             name: 'Growth',
           },
           {
             __typename: 'Item',
+            id: 'razor-leaf',
             name: 'Razor Leaf',
           },
           {
             __typename: 'Item',
+            id: 'solar-beam',
             name: 'Solar Beam',
           },
           {
             __typename: 'Item',
+            id: 'poison-powder',
             name: 'Poison Powder',
           },
           {
             __typename: 'Item',
+            id: 'sleep-powder',
             name: 'Sleep Powder',
           },
           {
             __typename: 'Item',
+            id: 'petal-dance',
             name: 'Petal Dance',
           },
           {
             __typename: 'Item',
+            id: 'string-shot',
             name: 'String Shot',
           },
           {
             __typename: 'Item',
+            id: 'toxic',
             name: 'Toxic',
           },
           {
             __typename: 'Item',
+            id: 'rage',
             name: 'Rage',
           },
           {
             __typename: 'Item',
+            id: 'mimic',
             name: 'Mimic',
           },
           {
             __typename: 'Item',
+            id: 'double-team',
             name: 'Double Team',
           },
           {
             __typename: 'Item',
+            id: 'defense-curl',
             name: 'Defense Curl',
           },
           {
             __typename: 'Item',
+            id: 'light-screen',
             name: 'Light Screen',
           },
           {
             __typename: 'Item',
+            id: 'reflect',
             name: 'Reflect',
           },
           {
             __typename: 'Item',
+            id: 'bide',
             name: 'Bide',
           },
           {
             __typename: 'Item',
+            id: 'sludge',
             name: 'Sludge',
           },
           {
             __typename: 'Item',
+            id: 'skull-bash',
             name: 'Skull Bash',
           },
           {
             __typename: 'Item',
+            id: 'amnesia',
             name: 'Amnesia',
           },
           {
             __typename: 'Item',
+            id: 'flash',
             name: 'Flash',
           },
           {
             __typename: 'Item',
+            id: 'rest',
             name: 'Rest',
           },
           {
             __typename: 'Item',
+            id: 'substitute',
             name: 'Substitute',
           },
           {
             __typename: 'Item',
+            id: 'snore',
             name: 'Snore',
           },
           {
             __typename: 'Item',
+            id: 'curse',
             name: 'Curse',
           },
           {
             __typename: 'Item',
+            id: 'protect',
             name: 'Protect',
           },
           {
             __typename: 'Item',
+            id: 'sludge-bomb',
             name: 'Sludge Bomb',
           },
           {
             __typename: 'Item',
+            id: 'mud-slap',
             name: 'Mud Slap',
           },
           {
             __typename: 'Item',
+            id: 'giga-drain',
             name: 'Giga Drain',
           },
           {
             __typename: 'Item',
+            id: 'endure',
             name: 'Endure',
           },
           {
             __typename: 'Item',
+            id: 'charm',
             name: 'Charm',
           },
           {
             __typename: 'Item',
+            id: 'swagger',
             name: 'Swagger',
           },
           {
             __typename: 'Item',
+            id: 'fury-cutter',
             name: 'Fury Cutter',
           },
           {
             __typename: 'Item',
+            id: 'attract',
             name: 'Attract',
           },
           {
             __typename: 'Item',
+            id: 'sleep-talk',
             name: 'Sleep Talk',
           },
           {
             __typename: 'Item',
+            id: 'return',
             name: 'Return',
           },
           {
             __typename: 'Item',
+            id: 'frustration',
             name: 'Frustration',
           },
           {
             __typename: 'Item',
+            id: 'safeguard',
             name: 'Safeguard',
           },
           {
             __typename: 'Item',
+            id: 'sweet-scent',
             name: 'Sweet Scent',
           },
           {
             __typename: 'Item',
+            id: 'synthesis',
             name: 'Synthesis',
           },
           {
             __typename: 'Item',
+            id: 'hidden-power',
             name: 'Hidden Power',
           },
           {
             __typename: 'Item',
+            id: 'sunny-day',
             name: 'Sunny Day',
           },
           {
             __typename: 'Item',
+            id: 'rock-smash',
             name: 'Rock Smash',
           },
           {
             __typename: 'Item',
+            id: 'facade',
             name: 'Facade',
           },
           {
             __typename: 'Item',
+            id: 'nature-power',
             name: 'Nature Power',
           },
           {
             __typename: 'Item',
+            id: 'ingrain',
             name: 'Ingrain',
           },
           {
             __typename: 'Item',
+            id: 'knock-off',
             name: 'Knock Off',
           },
           {
             __typename: 'Item',
+            id: 'secret-power',
             name: 'Secret Power',
           },
           {
             __typename: 'Item',
+            id: 'grass-whistle',
             name: 'Grass Whistle',
           },
           {
             __typename: 'Item',
+            id: 'bullet-seed',
             name: 'Bullet Seed',
           },
           {
             __typename: 'Item',
+            id: 'magical-leaf',
             name: 'Magical Leaf',
           },
           {
             __typename: 'Item',
+            id: 'natural-gift',
             name: 'Natural Gift',
           },
           {
             __typename: 'Item',
+            id: 'worry-seed',
             name: 'Worry Seed',
           },
           {
             __typename: 'Item',
+            id: 'seed-bomb',
             name: 'Seed Bomb',
           },
           {
             __typename: 'Item',
+            id: 'energy-ball',
             name: 'Energy Ball',
           },
           {
             __typename: 'Item',
+            id: 'leaf-storm',
             name: 'Leaf Storm',
           },
           {
             __typename: 'Item',
+            id: 'power-whip',
             name: 'Power Whip',
           },
           {
             __typename: 'Item',
+            id: 'captivate',
             name: 'Captivate',
           },
           {
             __typename: 'Item',
+            id: 'grass-knot',
             name: 'Grass Knot',
           },
           {
             __typename: 'Item',
+            id: 'venoshock',
             name: 'Venoshock',
           },
           {
             __typename: 'Item',
+            id: 'round',
             name: 'Round',
           },
           {
             __typename: 'Item',
+            id: 'echoed-voice',
             name: 'Echoed Voice',
           },
           {
             __typename: 'Item',
+            id: 'grass-pledge',
             name: 'Grass Pledge',
           },
           {
             __typename: 'Item',
+            id: 'work-up',
             name: 'Work Up',
           },
           {
             __typename: 'Item',
+            id: 'grassy-terrain',
             name: 'Grassy Terrain',
           },
           {
             __typename: 'Item',
+            id: 'confide',
             name: 'Confide',
           },
         ],
         species: {
           __typename: 'PokemonSpecies',
-          id: '1',
+          id: 'bulbasaur',
           growthRate: {
             __typename: 'PokemonGrowthRate',
-            id: '4',
+            id: 'medium-slow',
             levels: [
               {
                 __typename: 'GrowthRateExperienceLevel',
@@ -871,31 +952,37 @@ export const mockedGetPokemonQuery: MockedResponse<GetPokemonQuery> = {
         stats: [
           {
             __typename: 'Stat',
+            id: 'hp',
             name: 'HP',
             baseStat: 45,
           },
           {
             __typename: 'Stat',
+            id: 'attack',
             name: 'Attack',
             baseStat: 49,
           },
           {
             __typename: 'Stat',
+            id: 'defense',
             name: 'Defense',
             baseStat: 49,
           },
           {
             __typename: 'Stat',
+            id: 'special-attack',
             name: 'Special Attack',
             baseStat: 65,
           },
           {
             __typename: 'Stat',
+            id: 'special-defense',
             name: 'Special Defense',
             baseStat: 65,
           },
           {
             __typename: 'Stat',
+            id: 'speed',
             name: 'Speed',
             baseStat: 45,
           },
@@ -903,10 +990,12 @@ export const mockedGetPokemonQuery: MockedResponse<GetPokemonQuery> = {
         types: [
           {
             __typename: 'Item',
+            id: 'grass',
             name: 'Grass',
           },
           {
             __typename: 'Item',
+            id: 'poison',
             name: 'Poison',
           },
         ],

--- a/packages/web/src/__fixtures__/mockedListPokemonNameFilterQuery.ts
+++ b/packages/web/src/__fixtures__/mockedListPokemonNameFilterQuery.ts
@@ -26,7 +26,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MA',
             node: {
               __typename: 'PokemonNode',
-              id: '25',
+              id: 'pikachu',
+              pokedexNumber: 25,
               name: 'Pikachu',
               baseExperience: 112,
               order: 35,
@@ -38,6 +39,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -48,7 +50,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MQ',
             node: {
               __typename: 'PokemonNode',
-              id: '10080',
+              id: 'pikachu-rock-star',
+              pokedexNumber: 10080,
               name: 'Pikachu Rock Star',
               baseExperience: 112,
               order: 37,
@@ -60,6 +63,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -70,7 +74,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Mg',
             node: {
               __typename: 'PokemonNode',
-              id: '10081',
+              id: 'pikachu-belle',
+              pokedexNumber: 10081,
               name: 'Pikachu Belle',
               baseExperience: 112,
               order: 38,
@@ -82,6 +87,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -92,7 +98,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Mw',
             node: {
               __typename: 'PokemonNode',
-              id: '10082',
+              id: 'pikachu-pop-star',
+              pokedexNumber: 10082,
               name: 'Pikachu Pop Star',
               baseExperience: 112,
               order: 39,
@@ -104,6 +111,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -114,7 +122,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NA',
             node: {
               __typename: 'PokemonNode',
-              id: '10083',
+              id: 'pikachu-phd',
+              pokedexNumber: 10083,
               name: 'Pikachu Phd',
               baseExperience: 112,
               order: 40,
@@ -126,6 +135,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -136,7 +146,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NQ',
             node: {
               __typename: 'PokemonNode',
-              id: '10084',
+              id: 'pikachu-libre',
+              pokedexNumber: 10084,
               name: 'Pikachu Libre',
               baseExperience: 112,
               order: 41,
@@ -148,6 +159,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -158,7 +170,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Ng',
             node: {
               __typename: 'PokemonNode',
-              id: '10085',
+              id: 'pikachu-cosplay',
+              pokedexNumber: 10085,
               name: 'Pikachu Cosplay',
               baseExperience: 112,
               order: 36,
@@ -170,6 +183,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -180,7 +194,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Nw',
             node: {
               __typename: 'PokemonNode',
-              id: '10094',
+              id: 'pikachu-original-cap',
+              pokedexNumber: 10094,
               name: 'Pikachu Original Cap',
               baseExperience: 112,
               order: 42,
@@ -192,6 +207,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -202,7 +218,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'OA',
             node: {
               __typename: 'PokemonNode',
-              id: '10095',
+              id: 'pikachu-hoenn-cap',
+              pokedexNumber: 10095,
               name: 'Pikachu Hoenn Cap',
               baseExperience: 112,
               order: 43,
@@ -214,6 +231,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -224,7 +242,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'OQ',
             node: {
               __typename: 'PokemonNode',
-              id: '10096',
+              id: 'pikachu-sinnoh-cap',
+              pokedexNumber: 10096,
               name: 'Pikachu Sinnoh Cap',
               baseExperience: 112,
               order: 44,
@@ -236,6 +255,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -246,7 +266,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTA',
             node: {
               __typename: 'PokemonNode',
-              id: '10097',
+              id: 'pikachu-unova-cap',
+              pokedexNumber: 10097,
               name: 'Pikachu Unova Cap',
               baseExperience: 112,
               order: 45,
@@ -258,6 +279,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -268,7 +290,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTE',
             node: {
               __typename: 'PokemonNode',
-              id: '10098',
+              id: 'pikachu-kalos-cap',
+              pokedexNumber: 10098,
               name: 'Pikachu Kalos Cap',
               baseExperience: 112,
               order: 46,
@@ -280,6 +303,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -290,7 +314,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTI',
             node: {
               __typename: 'PokemonNode',
-              id: '10099',
+              id: 'pikachu-alola-cap',
+              pokedexNumber: 10099,
               name: 'Pikachu Alola Cap',
               baseExperience: 112,
               order: 47,
@@ -302,6 +327,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -312,7 +338,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTM',
             node: {
               __typename: 'PokemonNode',
-              id: '10148',
+              id: 'pikachu-partner-cap',
+              pokedexNumber: 10148,
               name: 'Pikachu Partner Cap',
               baseExperience: 112,
               order: 48,
@@ -324,6 +351,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -334,7 +362,8 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTQ',
             node: {
               __typename: 'PokemonNode',
-              id: '10190',
+              id: 'pikachu-gmax',
+              pokedexNumber: 10190,
               name: 'Pikachu Gmax',
               baseExperience: 112,
               order: -1,
@@ -346,6 +375,7 @@ export const mockedListPokemonNameFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],

--- a/packages/web/src/__fixtures__/mockedListPokemonNameSortQuery.ts
+++ b/packages/web/src/__fixtures__/mockedListPokemonNameSortQuery.ts
@@ -21,7 +21,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MA',
             node: {
               __typename: 'PokemonNode',
-              id: '460',
+              id: 'abomasnow',
+              pokedexNumber: 460,
               name: 'Abomasnow',
               baseExperience: 173,
               order: 567,
@@ -33,10 +34,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
                 {
                   __typename: 'Item',
+                  id: 'ice',
                   name: 'Ice',
                 },
               ],
@@ -47,7 +50,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MQ',
             node: {
               __typename: 'PokemonNode',
-              id: '10060',
+              id: 'abomasnow-mega',
+              pokedexNumber: 10060,
               name: 'Abomasnow Mega',
               baseExperience: 208,
               order: 568,
@@ -59,10 +63,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
                 {
                   __typename: 'Item',
+                  id: 'ice',
                   name: 'Ice',
                 },
               ],
@@ -73,7 +79,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'Mg',
             node: {
               __typename: 'PokemonNode',
-              id: '63',
+              id: 'abra',
+              pokedexNumber: 63,
               name: 'Abra',
               baseExperience: 62,
               order: 100,
@@ -85,6 +92,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'psychic',
                   name: 'Psychic',
                 },
               ],
@@ -95,7 +103,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'Mw',
             node: {
               __typename: 'PokemonNode',
-              id: '359',
+              id: 'absol',
+              pokedexNumber: 359,
               name: 'Absol',
               baseExperience: 163,
               order: 460,
@@ -107,6 +116,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'dark',
                   name: 'Dark',
                 },
               ],
@@ -117,7 +127,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'NA',
             node: {
               __typename: 'PokemonNode',
-              id: '10057',
+              id: 'absol-mega',
+              pokedexNumber: 10057,
               name: 'Absol Mega',
               baseExperience: 198,
               order: 461,
@@ -129,6 +140,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'dark',
                   name: 'Dark',
                 },
               ],
@@ -139,7 +151,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'NQ',
             node: {
               __typename: 'PokemonNode',
-              id: '617',
+              id: 'accelgor',
+              pokedexNumber: 617,
               name: 'Accelgor',
               baseExperience: 173,
               order: 717,
@@ -151,6 +164,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
               ],
@@ -161,7 +175,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'Ng',
             node: {
               __typename: 'PokemonNode',
-              id: '10026',
+              id: 'aegislash-blade',
+              pokedexNumber: 10026,
               name: 'Aegislash Blade',
               baseExperience: 234,
               order: 793,
@@ -173,10 +188,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'steel',
                   name: 'Steel',
                 },
                 {
                   __typename: 'Item',
+                  id: 'ghost',
                   name: 'Ghost',
                 },
               ],
@@ -187,7 +204,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'Nw',
             node: {
               __typename: 'PokemonNode',
-              id: '681',
+              id: 'aegislash-shield',
+              pokedexNumber: 681,
               name: 'Aegislash Shield',
               baseExperience: 234,
               order: 792,
@@ -199,10 +217,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'steel',
                   name: 'Steel',
                 },
                 {
                   __typename: 'Item',
+                  id: 'ghost',
                   name: 'Ghost',
                 },
               ],
@@ -213,7 +233,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'OA',
             node: {
               __typename: 'PokemonNode',
-              id: '142',
+              id: 'aerodactyl',
+              pokedexNumber: 142,
               name: 'Aerodactyl',
               baseExperience: 180,
               order: 220,
@@ -225,10 +246,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'rock',
                   name: 'Rock',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -239,7 +262,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'OQ',
             node: {
               __typename: 'PokemonNode',
-              id: '10042',
+              id: 'aerodactyl-mega',
+              pokedexNumber: 10042,
               name: 'Aerodactyl Mega',
               baseExperience: 215,
               order: 221,
@@ -251,10 +275,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'rock',
                   name: 'Rock',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -265,7 +291,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MTA',
             node: {
               __typename: 'PokemonNode',
-              id: '306',
+              id: 'aggron',
+              pokedexNumber: 306,
               name: 'Aggron',
               baseExperience: 239,
               order: 393,
@@ -277,10 +304,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'steel',
                   name: 'Steel',
                 },
                 {
                   __typename: 'Item',
+                  id: 'rock',
                   name: 'Rock',
                 },
               ],
@@ -291,7 +320,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MTE',
             node: {
               __typename: 'PokemonNode',
-              id: '10053',
+              id: 'aggron-mega',
+              pokedexNumber: 10053,
               name: 'Aggron Mega',
               baseExperience: 284,
               order: 394,
@@ -303,6 +333,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'steel',
                   name: 'Steel',
                 },
               ],
@@ -313,7 +344,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MTI',
             node: {
               __typename: 'PokemonNode',
-              id: '190',
+              id: 'aipom',
+              pokedexNumber: 190,
               name: 'Aipom',
               baseExperience: 72,
               order: 270,
@@ -325,6 +357,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -335,7 +368,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MTM',
             node: {
               __typename: 'PokemonNode',
-              id: '65',
+              id: 'alakazam',
+              pokedexNumber: 65,
               name: 'Alakazam',
               baseExperience: 225,
               order: 102,
@@ -347,6 +381,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'psychic',
                   name: 'Psychic',
                 },
               ],
@@ -357,7 +392,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MTQ',
             node: {
               __typename: 'PokemonNode',
-              id: '10037',
+              id: 'alakazam-mega',
+              pokedexNumber: 10037,
               name: 'Alakazam Mega',
               baseExperience: 270,
               order: 103,
@@ -369,6 +405,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'psychic',
                   name: 'Psychic',
                 },
               ],
@@ -379,7 +416,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MTU',
             node: {
               __typename: 'PokemonNode',
-              id: '869',
+              id: 'alcremie',
+              pokedexNumber: 869,
               name: 'Alcremie',
               baseExperience: 173,
               order: -1,
@@ -391,6 +429,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'fairy',
                   name: 'Fairy',
                 },
               ],
@@ -401,7 +440,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MTY',
             node: {
               __typename: 'PokemonNode',
-              id: '10214',
+              id: 'alcremie-gmax',
+              pokedexNumber: 10214,
               name: 'Alcremie Gmax',
               baseExperience: 173,
               order: -1,
@@ -413,6 +453,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'fairy',
                   name: 'Fairy',
                 },
               ],
@@ -423,7 +464,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MTc',
             node: {
               __typename: 'PokemonNode',
-              id: '594',
+              id: 'alomomola',
+              pokedexNumber: 594,
               name: 'Alomomola',
               baseExperience: 165,
               order: 694,
@@ -435,6 +477,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'water',
                   name: 'Water',
                 },
               ],
@@ -445,7 +488,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MTg',
             node: {
               __typename: 'PokemonNode',
-              id: '334',
+              id: 'altaria',
+              pokedexNumber: 334,
               name: 'Altaria',
               baseExperience: 172,
               order: 428,
@@ -457,10 +501,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'dragon',
                   name: 'Dragon',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -471,7 +517,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MTk',
             node: {
               __typename: 'PokemonNode',
-              id: '10067',
+              id: 'altaria-mega',
+              pokedexNumber: 10067,
               name: 'Altaria Mega',
               baseExperience: 207,
               order: 429,
@@ -483,10 +530,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'dragon',
                   name: 'Dragon',
                 },
                 {
                   __typename: 'Item',
+                  id: 'fairy',
                   name: 'Fairy',
                 },
               ],
@@ -497,7 +546,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MjA',
             node: {
               __typename: 'PokemonNode',
-              id: '698',
+              id: 'amaura',
+              pokedexNumber: 698,
               name: 'Amaura',
               baseExperience: 72,
               order: 810,
@@ -509,10 +559,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'rock',
                   name: 'Rock',
                 },
                 {
                   __typename: 'Item',
+                  id: 'ice',
                   name: 'Ice',
                 },
               ],
@@ -523,7 +575,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MjE',
             node: {
               __typename: 'PokemonNode',
-              id: '424',
+              id: 'ambipom',
+              pokedexNumber: 424,
               name: 'Ambipom',
               baseExperience: 169,
               order: 271,
@@ -535,6 +588,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -545,7 +599,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MjI',
             node: {
               __typename: 'PokemonNode',
-              id: '591',
+              id: 'amoonguss',
+              pokedexNumber: 591,
               name: 'Amoonguss',
               baseExperience: 162,
               order: 691,
@@ -557,10 +612,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -571,7 +628,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MjM',
             node: {
               __typename: 'PokemonNode',
-              id: '181',
+              id: 'ampharos',
+              pokedexNumber: 181,
               name: 'Ampharos',
               baseExperience: 230,
               order: 260,
@@ -583,6 +641,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -593,7 +652,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MjQ',
             node: {
               __typename: 'PokemonNode',
-              id: '10045',
+              id: 'ampharos-mega',
+              pokedexNumber: 10045,
               name: 'Ampharos Mega',
               baseExperience: 275,
               order: 261,
@@ -605,10 +665,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
                 {
                   __typename: 'Item',
+                  id: 'dragon',
                   name: 'Dragon',
                 },
               ],
@@ -619,7 +681,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MjU',
             node: {
               __typename: 'PokemonNode',
-              id: '347',
+              id: 'anorith',
+              pokedexNumber: 347,
               name: 'Anorith',
               baseExperience: 71,
               order: 442,
@@ -631,10 +694,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'rock',
                   name: 'Rock',
                 },
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
               ],
@@ -645,7 +710,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MjY',
             node: {
               __typename: 'PokemonNode',
-              id: '842',
+              id: 'appletun',
+              pokedexNumber: 842,
               name: 'Appletun',
               baseExperience: 170,
               order: -1,
@@ -657,10 +723,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
                 {
                   __typename: 'Item',
+                  id: 'dragon',
                   name: 'Dragon',
                 },
               ],
@@ -671,7 +739,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'Mjc',
             node: {
               __typename: 'PokemonNode',
-              id: '10208',
+              id: 'appletun-gmax',
+              pokedexNumber: 10208,
               name: 'Appletun Gmax',
               baseExperience: 170,
               order: -1,
@@ -683,10 +752,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
                 {
                   __typename: 'Item',
+                  id: 'dragon',
                   name: 'Dragon',
                 },
               ],
@@ -697,7 +768,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'Mjg',
             node: {
               __typename: 'PokemonNode',
-              id: '840',
+              id: 'applin',
+              pokedexNumber: 840,
               name: 'Applin',
               baseExperience: 52,
               order: -1,
@@ -709,10 +781,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
                 {
                   __typename: 'Item',
+                  id: 'dragon',
                   name: 'Dragon',
                 },
               ],
@@ -723,7 +797,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'Mjk',
             node: {
               __typename: 'PokemonNode',
-              id: '752',
+              id: 'araquanid',
+              pokedexNumber: 752,
               name: 'Araquanid',
               baseExperience: 159,
               order: 884,
@@ -735,10 +810,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'water',
                   name: 'Water',
                 },
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
               ],
@@ -749,7 +826,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MzA',
             node: {
               __typename: 'PokemonNode',
-              id: '10153',
+              id: 'araquanid-totem',
+              pokedexNumber: 10153,
               name: 'Araquanid Totem',
               baseExperience: 159,
               order: 885,
@@ -760,10 +838,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'water',
                   name: 'Water',
                 },
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
               ],
@@ -774,7 +854,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MzE',
             node: {
               __typename: 'PokemonNode',
-              id: '24',
+              id: 'arbok',
+              pokedexNumber: 24,
               name: 'Arbok',
               baseExperience: 157,
               order: 33,
@@ -786,6 +867,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -796,7 +878,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MzI',
             node: {
               __typename: 'PokemonNode',
-              id: '59',
+              id: 'arcanine',
+              pokedexNumber: 59,
               name: 'Arcanine',
               baseExperience: 194,
               order: 95,
@@ -808,6 +891,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'fire',
                   name: 'Fire',
                 },
               ],
@@ -818,7 +902,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MzM',
             node: {
               __typename: 'PokemonNode',
-              id: '493',
+              id: 'arceus',
+              pokedexNumber: 493,
               name: 'Arceus',
               baseExperience: 324,
               order: 590,
@@ -830,6 +915,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -840,7 +926,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MzQ',
             node: {
               __typename: 'PokemonNode',
-              id: '566',
+              id: 'archen',
+              pokedexNumber: 566,
               name: 'Archen',
               baseExperience: 71,
               order: 666,
@@ -852,10 +939,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'rock',
                   name: 'Rock',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -866,7 +955,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MzU',
             node: {
               __typename: 'PokemonNode',
-              id: '567',
+              id: 'archeops',
+              pokedexNumber: 567,
               name: 'Archeops',
               baseExperience: 177,
               order: 667,
@@ -878,10 +968,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'rock',
                   name: 'Rock',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -892,7 +984,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'MzY',
             node: {
               __typename: 'PokemonNode',
-              id: '883',
+              id: 'arctovish',
+              pokedexNumber: 883,
               name: 'Arctovish',
               baseExperience: 177,
               order: -1,
@@ -904,10 +997,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'water',
                   name: 'Water',
                 },
                 {
                   __typename: 'Item',
+                  id: 'ice',
                   name: 'Ice',
                 },
               ],
@@ -918,7 +1013,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'Mzc',
             node: {
               __typename: 'PokemonNode',
-              id: '881',
+              id: 'arctozolt',
+              pokedexNumber: 881,
               name: 'Arctozolt',
               baseExperience: 177,
               order: -1,
@@ -930,10 +1026,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
                 {
                   __typename: 'Item',
+                  id: 'ice',
                   name: 'Ice',
                 },
               ],
@@ -944,7 +1042,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'Mzg',
             node: {
               __typename: 'PokemonNode',
-              id: '168',
+              id: 'ariados',
+              pokedexNumber: 168,
               name: 'Ariados',
               baseExperience: 140,
               order: 250,
@@ -956,10 +1055,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -970,7 +1071,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'Mzk',
             node: {
               __typename: 'PokemonNode',
-              id: '348',
+              id: 'armaldo',
+              pokedexNumber: 348,
               name: 'Armaldo',
               baseExperience: 173,
               order: 443,
@@ -982,10 +1084,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'rock',
                   name: 'Rock',
                 },
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
               ],
@@ -996,7 +1100,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'NDA',
             node: {
               __typename: 'PokemonNode',
-              id: '683',
+              id: 'aromatisse',
+              pokedexNumber: 683,
               name: 'Aromatisse',
               baseExperience: 162,
               order: 795,
@@ -1008,6 +1113,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'fairy',
                   name: 'Fairy',
                 },
               ],
@@ -1018,7 +1124,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'NDE',
             node: {
               __typename: 'PokemonNode',
-              id: '304',
+              id: 'aron',
+              pokedexNumber: 304,
               name: 'Aron',
               baseExperience: 66,
               order: 391,
@@ -1030,10 +1137,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'steel',
                   name: 'Steel',
                 },
                 {
                   __typename: 'Item',
+                  id: 'rock',
                   name: 'Rock',
                 },
               ],
@@ -1044,7 +1153,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'NDI',
             node: {
               __typename: 'PokemonNode',
-              id: '846',
+              id: 'arrokuda',
+              pokedexNumber: 846,
               name: 'Arrokuda',
               baseExperience: 56,
               order: -1,
@@ -1056,6 +1166,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'water',
                   name: 'Water',
                 },
               ],
@@ -1066,7 +1177,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'NDM',
             node: {
               __typename: 'PokemonNode',
-              id: '144',
+              id: 'articuno',
+              pokedexNumber: 144,
               name: 'Articuno',
               baseExperience: 261,
               order: 224,
@@ -1078,10 +1190,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'ice',
                   name: 'Ice',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -1092,7 +1206,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'NDQ',
             node: {
               __typename: 'PokemonNode',
-              id: '10166',
+              id: 'articuno-galar',
+              pokedexNumber: 10166,
               name: 'Articuno Galar',
               baseExperience: 261,
               order: 224,
@@ -1104,10 +1219,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'psychic',
                   name: 'Psychic',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -1118,7 +1235,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'NDU',
             node: {
               __typename: 'PokemonNode',
-              id: '531',
+              id: 'audino',
+              pokedexNumber: 531,
               name: 'Audino',
               baseExperience: 390,
               order: 628,
@@ -1130,6 +1248,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -1140,7 +1259,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'NDY',
             node: {
               __typename: 'PokemonNode',
-              id: '10069',
+              id: 'audino-mega',
+              pokedexNumber: 10069,
               name: 'Audino Mega',
               baseExperience: 425,
               order: 629,
@@ -1152,10 +1272,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'fairy',
                   name: 'Fairy',
                 },
               ],
@@ -1166,7 +1288,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'NDc',
             node: {
               __typename: 'PokemonNode',
-              id: '699',
+              id: 'aurorus',
+              pokedexNumber: 699,
               name: 'Aurorus',
               baseExperience: 104,
               order: 811,
@@ -1178,10 +1301,12 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'rock',
                   name: 'Rock',
                 },
                 {
                   __typename: 'Item',
+                  id: 'ice',
                   name: 'Ice',
                 },
               ],
@@ -1192,7 +1317,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'NDg',
             node: {
               __typename: 'PokemonNode',
-              id: '713',
+              id: 'avalugg',
+              pokedexNumber: 713,
               name: 'Avalugg',
               baseExperience: 180,
               order: 830,
@@ -1204,6 +1330,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'ice',
                   name: 'Ice',
                 },
               ],
@@ -1214,7 +1341,8 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
             cursor: 'NDk',
             node: {
               __typename: 'PokemonNode',
-              id: '610',
+              id: 'axew',
+              pokedexNumber: 610,
               name: 'Axew',
               baseExperience: 64,
               order: 710,
@@ -1226,6 +1354,7 @@ export const mockedListPokemonNameSortQuery: MockedResponse<ListPokemonQuery> = 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'dragon',
                   name: 'Dragon',
                 },
               ],

--- a/packages/web/src/__fixtures__/mockedListPokemonQuery.ts
+++ b/packages/web/src/__fixtures__/mockedListPokemonQuery.ts
@@ -21,7 +21,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MA',
             node: {
               __typename: 'PokemonNode',
-              id: '1',
+              id: 'bulbasaur',
+              pokedexNumber: 1,
               name: 'Bulbasaur',
               baseExperience: 64,
               order: 1,
@@ -33,10 +34,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -47,7 +50,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MQ',
             node: {
               __typename: 'PokemonNode',
-              id: '2',
+              id: 'ivysaur',
+              pokedexNumber: 2,
               name: 'Ivysaur',
               baseExperience: 142,
               order: 2,
@@ -59,10 +63,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -73,7 +79,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'Mg',
             node: {
               __typename: 'PokemonNode',
-              id: '3',
+              id: 'venusaur',
+              pokedexNumber: 3,
               name: 'Venusaur',
               baseExperience: 236,
               order: 3,
@@ -85,10 +92,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -99,7 +108,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'Mw',
             node: {
               __typename: 'PokemonNode',
-              id: '4',
+              id: 'charmander',
+              pokedexNumber: 4,
               name: 'Charmander',
               baseExperience: 62,
               order: 5,
@@ -111,6 +121,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'fire',
                   name: 'Fire',
                 },
               ],
@@ -121,7 +132,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'NA',
             node: {
               __typename: 'PokemonNode',
-              id: '5',
+              id: 'charmeleon',
+              pokedexNumber: 5,
               name: 'Charmeleon',
               baseExperience: 142,
               order: 6,
@@ -133,6 +145,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'fire',
                   name: 'Fire',
                 },
               ],
@@ -143,7 +156,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'NQ',
             node: {
               __typename: 'PokemonNode',
-              id: '6',
+              id: 'charizard',
+              pokedexNumber: 6,
               name: 'Charizard',
               baseExperience: 240,
               order: 7,
@@ -155,10 +169,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'fire',
                   name: 'Fire',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -169,7 +185,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'Ng',
             node: {
               __typename: 'PokemonNode',
-              id: '7',
+              id: 'squirtle',
+              pokedexNumber: 7,
               name: 'Squirtle',
               baseExperience: 63,
               order: 10,
@@ -181,6 +198,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'water',
                   name: 'Water',
                 },
               ],
@@ -191,7 +209,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'Nw',
             node: {
               __typename: 'PokemonNode',
-              id: '8',
+              id: 'wartortle',
+              pokedexNumber: 8,
               name: 'Wartortle',
               baseExperience: 142,
               order: 11,
@@ -203,6 +222,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'water',
                   name: 'Water',
                 },
               ],
@@ -213,7 +233,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'OA',
             node: {
               __typename: 'PokemonNode',
-              id: '9',
+              id: 'blastoise',
+              pokedexNumber: 9,
               name: 'Blastoise',
               baseExperience: 239,
               order: 12,
@@ -225,6 +246,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'water',
                   name: 'Water',
                 },
               ],
@@ -235,7 +257,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'OQ',
             node: {
               __typename: 'PokemonNode',
-              id: '10',
+              id: 'caterpie',
+              pokedexNumber: 10,
               name: 'Caterpie',
               baseExperience: 39,
               order: 14,
@@ -247,6 +270,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
               ],
@@ -257,7 +281,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MTA',
             node: {
               __typename: 'PokemonNode',
-              id: '11',
+              id: 'metapod',
+              pokedexNumber: 11,
               name: 'Metapod',
               baseExperience: 72,
               order: 15,
@@ -269,6 +294,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
               ],
@@ -279,7 +305,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MTE',
             node: {
               __typename: 'PokemonNode',
-              id: '12',
+              id: 'butterfree',
+              pokedexNumber: 12,
               name: 'Butterfree',
               baseExperience: 178,
               order: 16,
@@ -291,10 +318,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -305,7 +334,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MTI',
             node: {
               __typename: 'PokemonNode',
-              id: '13',
+              id: 'weedle',
+              pokedexNumber: 13,
               name: 'Weedle',
               baseExperience: 39,
               order: 17,
@@ -317,10 +347,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -331,7 +363,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MTM',
             node: {
               __typename: 'PokemonNode',
-              id: '14',
+              id: 'kakuna',
+              pokedexNumber: 14,
               name: 'Kakuna',
               baseExperience: 72,
               order: 18,
@@ -343,10 +376,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -357,7 +392,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MTQ',
             node: {
               __typename: 'PokemonNode',
-              id: '15',
+              id: 'beedrill',
+              pokedexNumber: 15,
               name: 'Beedrill',
               baseExperience: 178,
               order: 19,
@@ -369,10 +405,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -383,7 +421,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MTU',
             node: {
               __typename: 'PokemonNode',
-              id: '16',
+              id: 'pidgey',
+              pokedexNumber: 16,
               name: 'Pidgey',
               baseExperience: 50,
               order: 21,
@@ -395,10 +434,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -409,7 +450,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MTY',
             node: {
               __typename: 'PokemonNode',
-              id: '17',
+              id: 'pidgeotto',
+              pokedexNumber: 17,
               name: 'Pidgeotto',
               baseExperience: 122,
               order: 22,
@@ -421,10 +463,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -435,7 +479,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MTc',
             node: {
               __typename: 'PokemonNode',
-              id: '18',
+              id: 'pidgeot',
+              pokedexNumber: 18,
               name: 'Pidgeot',
               baseExperience: 216,
               order: 23,
@@ -447,10 +492,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -461,7 +508,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MTg',
             node: {
               __typename: 'PokemonNode',
-              id: '19',
+              id: 'rattata',
+              pokedexNumber: 19,
               name: 'Rattata',
               baseExperience: 51,
               order: 25,
@@ -473,6 +521,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -483,7 +532,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MTk',
             node: {
               __typename: 'PokemonNode',
-              id: '20',
+              id: 'raticate',
+              pokedexNumber: 20,
               name: 'Raticate',
               baseExperience: 145,
               order: 27,
@@ -495,6 +545,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -505,7 +556,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MjA',
             node: {
               __typename: 'PokemonNode',
-              id: '21',
+              id: 'spearow',
+              pokedexNumber: 21,
               name: 'Spearow',
               baseExperience: 52,
               order: 30,
@@ -517,10 +569,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -531,7 +585,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MjE',
             node: {
               __typename: 'PokemonNode',
-              id: '22',
+              id: 'fearow',
+              pokedexNumber: 22,
               name: 'Fearow',
               baseExperience: 155,
               order: 31,
@@ -543,10 +598,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -557,7 +614,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MjI',
             node: {
               __typename: 'PokemonNode',
-              id: '23',
+              id: 'ekans',
+              pokedexNumber: 23,
               name: 'Ekans',
               baseExperience: 58,
               order: 32,
@@ -569,6 +627,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -579,7 +638,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MjM',
             node: {
               __typename: 'PokemonNode',
-              id: '24',
+              id: 'arbok',
+              pokedexNumber: 24,
               name: 'Arbok',
               baseExperience: 157,
               order: 33,
@@ -591,6 +651,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -601,7 +662,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MjQ',
             node: {
               __typename: 'PokemonNode',
-              id: '25',
+              id: 'pikachu',
+              pokedexNumber: 25,
               name: 'Pikachu',
               baseExperience: 112,
               order: 35,
@@ -613,6 +675,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -623,7 +686,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MjU',
             node: {
               __typename: 'PokemonNode',
-              id: '26',
+              id: 'raichu',
+              pokedexNumber: 26,
               name: 'Raichu',
               baseExperience: 218,
               order: 49,
@@ -635,6 +699,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'electric',
                   name: 'Electric',
                 },
               ],
@@ -645,7 +710,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MjY',
             node: {
               __typename: 'PokemonNode',
-              id: '27',
+              id: 'sandshrew',
+              pokedexNumber: 27,
               name: 'Sandshrew',
               baseExperience: 60,
               order: 51,
@@ -657,6 +723,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'ground',
                   name: 'Ground',
                 },
               ],
@@ -667,7 +734,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'Mjc',
             node: {
               __typename: 'PokemonNode',
-              id: '28',
+              id: 'sandslash',
+              pokedexNumber: 28,
               name: 'Sandslash',
               baseExperience: 158,
               order: 53,
@@ -679,6 +747,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'ground',
                   name: 'Ground',
                 },
               ],
@@ -689,7 +758,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'Mjg',
             node: {
               __typename: 'PokemonNode',
-              id: '29',
+              id: 'nidoran-f',
+              pokedexNumber: 29,
               name: 'Nidoran F',
               baseExperience: 55,
               order: 55,
@@ -701,6 +771,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -711,7 +782,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'Mjk',
             node: {
               __typename: 'PokemonNode',
-              id: '30',
+              id: 'nidorina',
+              pokedexNumber: 30,
               name: 'Nidorina',
               baseExperience: 128,
               order: 56,
@@ -723,6 +795,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -733,7 +806,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MzA',
             node: {
               __typename: 'PokemonNode',
-              id: '31',
+              id: 'nidoqueen',
+              pokedexNumber: 31,
               name: 'Nidoqueen',
               baseExperience: 227,
               order: 57,
@@ -745,10 +819,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
                 {
                   __typename: 'Item',
+                  id: 'ground',
                   name: 'Ground',
                 },
               ],
@@ -759,7 +835,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MzE',
             node: {
               __typename: 'PokemonNode',
-              id: '32',
+              id: 'nidoran-m',
+              pokedexNumber: 32,
               name: 'Nidoran M',
               baseExperience: 55,
               order: 58,
@@ -771,6 +848,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -781,7 +859,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MzI',
             node: {
               __typename: 'PokemonNode',
-              id: '33',
+              id: 'nidorino',
+              pokedexNumber: 33,
               name: 'Nidorino',
               baseExperience: 128,
               order: 59,
@@ -793,6 +872,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -803,7 +883,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MzM',
             node: {
               __typename: 'PokemonNode',
-              id: '34',
+              id: 'nidoking',
+              pokedexNumber: 34,
               name: 'Nidoking',
               baseExperience: 227,
               order: 60,
@@ -815,10 +896,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
                 {
                   __typename: 'Item',
+                  id: 'ground',
                   name: 'Ground',
                 },
               ],
@@ -829,7 +912,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MzQ',
             node: {
               __typename: 'PokemonNode',
-              id: '35',
+              id: 'clefairy',
+              pokedexNumber: 35,
               name: 'Clefairy',
               baseExperience: 113,
               order: 62,
@@ -841,6 +925,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'fairy',
                   name: 'Fairy',
                 },
               ],
@@ -851,7 +936,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MzU',
             node: {
               __typename: 'PokemonNode',
-              id: '36',
+              id: 'clefable',
+              pokedexNumber: 36,
               name: 'Clefable',
               baseExperience: 217,
               order: 63,
@@ -863,6 +949,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'fairy',
                   name: 'Fairy',
                 },
               ],
@@ -873,7 +960,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'MzY',
             node: {
               __typename: 'PokemonNode',
-              id: '37',
+              id: 'vulpix',
+              pokedexNumber: 37,
               name: 'Vulpix',
               baseExperience: 60,
               order: 64,
@@ -885,6 +973,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'fire',
                   name: 'Fire',
                 },
               ],
@@ -895,7 +984,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'Mzc',
             node: {
               __typename: 'PokemonNode',
-              id: '38',
+              id: 'ninetales',
+              pokedexNumber: 38,
               name: 'Ninetales',
               baseExperience: 177,
               order: 66,
@@ -907,6 +997,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'fire',
                   name: 'Fire',
                 },
               ],
@@ -917,7 +1008,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'Mzg',
             node: {
               __typename: 'PokemonNode',
-              id: '39',
+              id: 'jigglypuff',
+              pokedexNumber: 39,
               name: 'Jigglypuff',
               baseExperience: 95,
               order: 69,
@@ -929,10 +1021,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'fairy',
                   name: 'Fairy',
                 },
               ],
@@ -943,7 +1037,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'Mzk',
             node: {
               __typename: 'PokemonNode',
-              id: '40',
+              id: 'wigglytuff',
+              pokedexNumber: 40,
               name: 'Wigglytuff',
               baseExperience: 196,
               order: 70,
@@ -955,10 +1050,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'fairy',
                   name: 'Fairy',
                 },
               ],
@@ -969,7 +1066,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'NDA',
             node: {
               __typename: 'PokemonNode',
-              id: '41',
+              id: 'zubat',
+              pokedexNumber: 41,
               name: 'Zubat',
               baseExperience: 49,
               order: 71,
@@ -981,10 +1079,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -995,7 +1095,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'NDE',
             node: {
               __typename: 'PokemonNode',
-              id: '42',
+              id: 'golbat',
+              pokedexNumber: 42,
               name: 'Golbat',
               baseExperience: 159,
               order: 72,
@@ -1007,10 +1108,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -1021,7 +1124,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'NDI',
             node: {
               __typename: 'PokemonNode',
-              id: '43',
+              id: 'oddish',
+              pokedexNumber: 43,
               name: 'Oddish',
               baseExperience: 64,
               order: 74,
@@ -1033,10 +1137,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -1047,7 +1153,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'NDM',
             node: {
               __typename: 'PokemonNode',
-              id: '44',
+              id: 'gloom',
+              pokedexNumber: 44,
               name: 'Gloom',
               baseExperience: 138,
               order: 75,
@@ -1059,10 +1166,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -1073,7 +1182,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'NDQ',
             node: {
               __typename: 'PokemonNode',
-              id: '45',
+              id: 'vileplume',
+              pokedexNumber: 45,
               name: 'Vileplume',
               baseExperience: 221,
               order: 76,
@@ -1085,10 +1195,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -1099,7 +1211,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'NDU',
             node: {
               __typename: 'PokemonNode',
-              id: '46',
+              id: 'paras',
+              pokedexNumber: 46,
               name: 'Paras',
               baseExperience: 57,
               order: 78,
@@ -1111,10 +1224,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
               ],
@@ -1125,7 +1240,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'NDY',
             node: {
               __typename: 'PokemonNode',
-              id: '47',
+              id: 'parasect',
+              pokedexNumber: 47,
               name: 'Parasect',
               baseExperience: 142,
               order: 79,
@@ -1137,10 +1253,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
               ],
@@ -1151,7 +1269,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'NDc',
             node: {
               __typename: 'PokemonNode',
-              id: '48',
+              id: 'venonat',
+              pokedexNumber: 48,
               name: 'Venonat',
               baseExperience: 61,
               order: 80,
@@ -1163,10 +1282,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -1177,7 +1298,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'NDg',
             node: {
               __typename: 'PokemonNode',
-              id: '49',
+              id: 'venomoth',
+              pokedexNumber: 49,
               name: 'Venomoth',
               baseExperience: 158,
               order: 81,
@@ -1189,10 +1311,12 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'bug',
                   name: 'Bug',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],
@@ -1203,7 +1327,8 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
             cursor: 'NDk',
             node: {
               __typename: 'PokemonNode',
-              id: '50',
+              id: 'diglett',
+              pokedexNumber: 50,
               name: 'Diglett',
               baseExperience: 53,
               order: 82,
@@ -1215,6 +1340,7 @@ export const mockedListPokemonQuery: MockedResponse<ListPokemonQuery> = {
               types: [
                 {
                   __typename: 'Item',
+                  id: 'ground',
                   name: 'Ground',
                 },
               ],

--- a/packages/web/src/__fixtures__/mockedListPokemonSpeciesFilterQuery.ts
+++ b/packages/web/src/__fixtures__/mockedListPokemonSpeciesFilterQuery.ts
@@ -24,7 +24,8 @@ export const mockedListPokemonSpeciesFilterQuery: MockedResponse<ListPokemonQuer
             cursor: 'MA',
             node: {
               __typename: 'PokemonNode',
-              id: '1',
+              id: 'bulbasaur',
+              pokedexNumber: 1,
               name: 'Bulbasaur',
               baseExperience: 64,
               order: 1,
@@ -36,10 +37,12 @@ export const mockedListPokemonSpeciesFilterQuery: MockedResponse<ListPokemonQuer
               types: [
                 {
                   __typename: 'Item',
+                  id: 'grass',
                   name: 'Grass',
                 },
                 {
                   __typename: 'Item',
+                  id: 'poison',
                   name: 'Poison',
                 },
               ],

--- a/packages/web/src/__fixtures__/mockedListPokemonTypeFilterQuery.ts
+++ b/packages/web/src/__fixtures__/mockedListPokemonTypeFilterQuery.ts
@@ -24,7 +24,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MA',
             node: {
               __typename: 'PokemonNode',
-              id: '16',
+              id: 'pidgey',
+              pokedexNumber: 16,
               name: 'Pidgey',
               baseExperience: 50,
               order: 21,
@@ -36,10 +37,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -50,7 +53,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MQ',
             node: {
               __typename: 'PokemonNode',
-              id: '17',
+              id: 'pidgeotto',
+              pokedexNumber: 17,
               name: 'Pidgeotto',
               baseExperience: 122,
               order: 22,
@@ -62,10 +66,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -76,7 +82,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Mg',
             node: {
               __typename: 'PokemonNode',
-              id: '18',
+              id: 'pidgeot',
+              pokedexNumber: 18,
               name: 'Pidgeot',
               baseExperience: 216,
               order: 23,
@@ -88,10 +95,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -102,7 +111,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Mw',
             node: {
               __typename: 'PokemonNode',
-              id: '19',
+              id: 'rattata',
+              pokedexNumber: 19,
               name: 'Rattata',
               baseExperience: 51,
               order: 25,
@@ -114,6 +124,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -124,7 +135,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NA',
             node: {
               __typename: 'PokemonNode',
-              id: '20',
+              id: 'raticate',
+              pokedexNumber: 20,
               name: 'Raticate',
               baseExperience: 145,
               order: 27,
@@ -136,6 +148,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -146,7 +159,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NQ',
             node: {
               __typename: 'PokemonNode',
-              id: '21',
+              id: 'spearow',
+              pokedexNumber: 21,
               name: 'Spearow',
               baseExperience: 52,
               order: 30,
@@ -158,10 +172,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -172,7 +188,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Ng',
             node: {
               __typename: 'PokemonNode',
-              id: '22',
+              id: 'fearow',
+              pokedexNumber: 22,
               name: 'Fearow',
               baseExperience: 155,
               order: 31,
@@ -184,10 +201,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -198,7 +217,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Nw',
             node: {
               __typename: 'PokemonNode',
-              id: '39',
+              id: 'jigglypuff',
+              pokedexNumber: 39,
               name: 'Jigglypuff',
               baseExperience: 95,
               order: 69,
@@ -210,10 +230,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'fairy',
                   name: 'Fairy',
                 },
               ],
@@ -224,7 +246,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'OA',
             node: {
               __typename: 'PokemonNode',
-              id: '40',
+              id: 'wigglytuff',
+              pokedexNumber: 40,
               name: 'Wigglytuff',
               baseExperience: 196,
               order: 70,
@@ -236,10 +259,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'fairy',
                   name: 'Fairy',
                 },
               ],
@@ -250,7 +275,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'OQ',
             node: {
               __typename: 'PokemonNode',
-              id: '52',
+              id: 'meowth',
+              pokedexNumber: 52,
               name: 'Meowth',
               baseExperience: 58,
               order: 86,
@@ -262,6 +288,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -272,7 +299,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTA',
             node: {
               __typename: 'PokemonNode',
-              id: '53',
+              id: 'persian',
+              pokedexNumber: 53,
               name: 'Persian',
               baseExperience: 154,
               order: 88,
@@ -284,6 +312,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -294,7 +323,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTE',
             node: {
               __typename: 'PokemonNode',
-              id: '83',
+              id: 'farfetchd',
+              pokedexNumber: 83,
               name: 'Farfetchd',
               baseExperience: 132,
               order: 127,
@@ -306,10 +336,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -320,7 +352,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTI',
             node: {
               __typename: 'PokemonNode',
-              id: '84',
+              id: 'doduo',
+              pokedexNumber: 84,
               name: 'Doduo',
               baseExperience: 62,
               order: 128,
@@ -332,10 +365,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -346,7 +381,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTM',
             node: {
               __typename: 'PokemonNode',
-              id: '85',
+              id: 'dodrio',
+              pokedexNumber: 85,
               name: 'Dodrio',
               baseExperience: 165,
               order: 129,
@@ -358,10 +394,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -372,7 +410,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTQ',
             node: {
               __typename: 'PokemonNode',
-              id: '108',
+              id: 'lickitung',
+              pokedexNumber: 108,
               name: 'Lickitung',
               baseExperience: 77,
               order: 162,
@@ -384,6 +423,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -394,7 +434,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTU',
             node: {
               __typename: 'PokemonNode',
-              id: '113',
+              id: 'chansey',
+              pokedexNumber: 113,
               name: 'Chansey',
               baseExperience: 395,
               order: 170,
@@ -406,6 +447,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -416,7 +458,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTY',
             node: {
               __typename: 'PokemonNode',
-              id: '115',
+              id: 'kangaskhan',
+              pokedexNumber: 115,
               name: 'Kangaskhan',
               baseExperience: 172,
               order: 174,
@@ -428,6 +471,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -438,7 +482,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTc',
             node: {
               __typename: 'PokemonNode',
-              id: '128',
+              id: 'tauros',
+              pokedexNumber: 128,
               name: 'Tauros',
               baseExperience: 172,
               order: 198,
@@ -450,6 +495,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -460,7 +506,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTg',
             node: {
               __typename: 'PokemonNode',
-              id: '132',
+              id: 'ditto',
+              pokedexNumber: 132,
               name: 'Ditto',
               baseExperience: 101,
               order: 203,
@@ -472,6 +519,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -482,7 +530,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MTk',
             node: {
               __typename: 'PokemonNode',
-              id: '133',
+              id: 'eevee',
+              pokedexNumber: 133,
               name: 'Eevee',
               baseExperience: 65,
               order: 204,
@@ -494,6 +543,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -504,7 +554,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MjA',
             node: {
               __typename: 'PokemonNode',
-              id: '137',
+              id: 'porygon',
+              pokedexNumber: 137,
               name: 'Porygon',
               baseExperience: 79,
               order: 213,
@@ -516,6 +567,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -526,7 +578,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MjE',
             node: {
               __typename: 'PokemonNode',
-              id: '143',
+              id: 'snorlax',
+              pokedexNumber: 143,
               name: 'Snorlax',
               baseExperience: 189,
               order: 223,
@@ -538,6 +591,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -548,7 +602,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MjI',
             node: {
               __typename: 'PokemonNode',
-              id: '161',
+              id: 'sentret',
+              pokedexNumber: 161,
               name: 'Sentret',
               baseExperience: 43,
               order: 243,
@@ -560,6 +615,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -570,7 +626,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MjM',
             node: {
               __typename: 'PokemonNode',
-              id: '162',
+              id: 'furret',
+              pokedexNumber: 162,
               name: 'Furret',
               baseExperience: 145,
               order: 244,
@@ -582,6 +639,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -592,7 +650,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MjQ',
             node: {
               __typename: 'PokemonNode',
-              id: '163',
+              id: 'hoothoot',
+              pokedexNumber: 163,
               name: 'Hoothoot',
               baseExperience: 52,
               order: 245,
@@ -604,10 +663,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -618,7 +679,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MjU',
             node: {
               __typename: 'PokemonNode',
-              id: '164',
+              id: 'noctowl',
+              pokedexNumber: 164,
               name: 'Noctowl',
               baseExperience: 158,
               order: 246,
@@ -630,10 +692,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -644,7 +708,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MjY',
             node: {
               __typename: 'PokemonNode',
-              id: '174',
+              id: 'igglybuff',
+              pokedexNumber: 174,
               name: 'Igglybuff',
               baseExperience: 42,
               order: 68,
@@ -656,10 +721,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'fairy',
                   name: 'Fairy',
                 },
               ],
@@ -670,7 +737,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Mjc',
             node: {
               __typename: 'PokemonNode',
-              id: '190',
+              id: 'aipom',
+              pokedexNumber: 190,
               name: 'Aipom',
               baseExperience: 72,
               order: 270,
@@ -682,6 +750,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -692,7 +761,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Mjg',
             node: {
               __typename: 'PokemonNode',
-              id: '203',
+              id: 'girafarig',
+              pokedexNumber: 203,
               name: 'Girafarig',
               baseExperience: 159,
               order: 285,
@@ -704,10 +774,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'psychic',
                   name: 'Psychic',
                 },
               ],
@@ -718,7 +790,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Mjk',
             node: {
               __typename: 'PokemonNode',
-              id: '206',
+              id: 'dunsparce',
+              pokedexNumber: 206,
               name: 'Dunsparce',
               baseExperience: 145,
               order: 288,
@@ -730,6 +803,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -740,7 +814,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MzA',
             node: {
               __typename: 'PokemonNode',
-              id: '216',
+              id: 'teddiursa',
+              pokedexNumber: 216,
               name: 'Teddiursa',
               baseExperience: 66,
               order: 299,
@@ -752,6 +827,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -762,7 +838,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MzE',
             node: {
               __typename: 'PokemonNode',
-              id: '217',
+              id: 'ursaring',
+              pokedexNumber: 217,
               name: 'Ursaring',
               baseExperience: 175,
               order: 300,
@@ -774,6 +851,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -784,7 +862,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MzI',
             node: {
               __typename: 'PokemonNode',
-              id: '233',
+              id: 'porygon2',
+              pokedexNumber: 233,
               name: 'Porygon2',
               baseExperience: 180,
               order: 214,
@@ -796,6 +875,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -806,7 +886,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MzM',
             node: {
               __typename: 'PokemonNode',
-              id: '234',
+              id: 'stantler',
+              pokedexNumber: 234,
               name: 'Stantler',
               baseExperience: 163,
               order: 318,
@@ -818,6 +899,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -828,7 +910,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MzQ',
             node: {
               __typename: 'PokemonNode',
-              id: '235',
+              id: 'smeargle',
+              pokedexNumber: 235,
               name: 'Smeargle',
               baseExperience: 88,
               order: 319,
@@ -840,6 +923,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -850,7 +934,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MzU',
             node: {
               __typename: 'PokemonNode',
-              id: '241',
+              id: 'miltank',
+              pokedexNumber: 241,
               name: 'Miltank',
               baseExperience: 172,
               order: 320,
@@ -862,6 +947,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -872,7 +958,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'MzY',
             node: {
               __typename: 'PokemonNode',
-              id: '242',
+              id: 'blissey',
+              pokedexNumber: 242,
               name: 'Blissey',
               baseExperience: 608,
               order: 171,
@@ -884,6 +971,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -894,7 +982,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Mzc',
             node: {
               __typename: 'PokemonNode',
-              id: '263',
+              id: 'zigzagoon',
+              pokedexNumber: 263,
               name: 'Zigzagoon',
               baseExperience: 56,
               order: 345,
@@ -906,6 +995,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -916,7 +1006,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Mzg',
             node: {
               __typename: 'PokemonNode',
-              id: '264',
+              id: 'linoone',
+              pokedexNumber: 264,
               name: 'Linoone',
               baseExperience: 147,
               order: 346,
@@ -928,6 +1019,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -938,7 +1030,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'Mzk',
             node: {
               __typename: 'PokemonNode',
-              id: '276',
+              id: 'taillow',
+              pokedexNumber: 276,
               name: 'Taillow',
               baseExperience: 54,
               order: 358,
@@ -950,10 +1043,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -964,7 +1059,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NDA',
             node: {
               __typename: 'PokemonNode',
-              id: '277',
+              id: 'swellow',
+              pokedexNumber: 277,
               name: 'Swellow',
               baseExperience: 159,
               order: 359,
@@ -976,10 +1072,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'flying',
                   name: 'Flying',
                 },
               ],
@@ -990,7 +1088,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NDE',
             node: {
               __typename: 'PokemonNode',
-              id: '287',
+              id: 'slakoth',
+              pokedexNumber: 287,
               name: 'Slakoth',
               baseExperience: 56,
               order: 372,
@@ -1002,6 +1101,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -1012,7 +1112,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NDI',
             node: {
               __typename: 'PokemonNode',
-              id: '288',
+              id: 'vigoroth',
+              pokedexNumber: 288,
               name: 'Vigoroth',
               baseExperience: 154,
               order: 373,
@@ -1024,6 +1125,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -1034,7 +1136,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NDM',
             node: {
               __typename: 'PokemonNode',
-              id: '289',
+              id: 'slaking',
+              pokedexNumber: 289,
               name: 'Slaking',
               baseExperience: 252,
               order: 374,
@@ -1046,6 +1149,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -1056,7 +1160,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NDQ',
             node: {
               __typename: 'PokemonNode',
-              id: '293',
+              id: 'whismur',
+              pokedexNumber: 293,
               name: 'Whismur',
               baseExperience: 48,
               order: 378,
@@ -1068,6 +1173,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -1078,7 +1184,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NDU',
             node: {
               __typename: 'PokemonNode',
-              id: '294',
+              id: 'loudred',
+              pokedexNumber: 294,
               name: 'Loudred',
               baseExperience: 126,
               order: 379,
@@ -1090,6 +1197,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -1100,7 +1208,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NDY',
             node: {
               __typename: 'PokemonNode',
-              id: '295',
+              id: 'exploud',
+              pokedexNumber: 295,
               name: 'Exploud',
               baseExperience: 221,
               order: 380,
@@ -1112,6 +1221,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -1122,7 +1232,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NDc',
             node: {
               __typename: 'PokemonNode',
-              id: '298',
+              id: 'azurill',
+              pokedexNumber: 298,
               name: 'Azurill',
               baseExperience: 38,
               order: 262,
@@ -1134,10 +1245,12 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
                 {
                   __typename: 'Item',
+                  id: 'fairy',
                   name: 'Fairy',
                 },
               ],
@@ -1148,7 +1261,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NDg',
             node: {
               __typename: 'PokemonNode',
-              id: '300',
+              id: 'skitty',
+              pokedexNumber: 300,
               name: 'Skitty',
               baseExperience: 52,
               order: 385,
@@ -1160,6 +1274,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],
@@ -1170,7 +1285,8 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
             cursor: 'NDk',
             node: {
               __typename: 'PokemonNode',
-              id: '301',
+              id: 'delcatty',
+              pokedexNumber: 301,
               name: 'Delcatty',
               baseExperience: 140,
               order: 386,
@@ -1182,6 +1298,7 @@ export const mockedListPokemonTypeFilterQuery: MockedResponse<ListPokemonQuery> 
               types: [
                 {
                   __typename: 'Item',
+                  id: 'normal',
                   name: 'Normal',
                 },
               ],

--- a/packages/web/src/components/PokemonDetails/AttributeList.tsx
+++ b/packages/web/src/components/PokemonDetails/AttributeList.tsx
@@ -11,12 +11,16 @@ const useStyles = makeStyles(() =>
 );
 
 export type AttributeListProps = {
-  items: (Item | null)[];
-  title: string;
+  items?: (Item | null)[] | null;
+  title?: string;
 };
 
 export const AttributeList = ({ items, title }: AttributeListProps) => {
   const styles = useStyles();
+
+  if (!items) {
+    return null;
+  }
 
   return (
     <>

--- a/packages/web/src/components/PokemonDetails/PokemonAttributes.tsx
+++ b/packages/web/src/components/PokemonDetails/PokemonAttributes.tsx
@@ -6,25 +6,37 @@ import { PokemonGrowthChart } from './PokemonGrowthChart';
 export const PokemonAttributes = () => {
   const { pokemon } = usePokemonDetails();
 
-  const attributes: AttributeTableTuple[] = pokemon
-    ? [
-        ['Base Experience', `${pokemon.baseExperience} XP`],
-        ['Weight', `${pokemon.weight / 10}kg`],
-        ['Height', `${pokemon.height / 10}m`],
-      ]
-    : [];
+  if (!pokemon) {
+    return null;
+  }
 
-  const stats: AttributeTableTuple[] =
-    pokemon?.stats?.map((stat) => [stat?.name, stat?.baseStat]) || [];
+  const {
+    baseExperience,
+    weight,
+    height,
+    abilities,
+    heldItems,
+    moves,
+    stats,
+  } = pokemon;
 
-  return pokemon ? (
+  const attributes: AttributeTableTuple[] = [
+    ['Base Experience', `${baseExperience} XP`],
+    ['Weight', weight ? `${weight / 10}kg` : '?'],
+    ['Height', height ? `${height / 10}m` : '?'],
+  ];
+
+  const statAttributes: AttributeTableTuple[] =
+    stats?.map((stat) => [stat?.name, stat?.baseStat]) || [];
+
+  return (
     <>
       <AttributeTable attributes={attributes} />
       <PokemonGrowthChart />
-      <AttributeTable attributes={stats} />
-      <AttributeList items={pokemon.abilities} title="Possible Abilities" />
-      <AttributeList items={pokemon.heldItems} title="Held Items" />
-      <AttributeList items={pokemon.moves} title="Learnable Moves" />
+      <AttributeTable attributes={statAttributes} />
+      <AttributeList items={abilities} title="Possible Abilities" />
+      <AttributeList items={heldItems} title="Held Items" />
+      <AttributeList items={moves} title="Learnable Moves" />
     </>
-  ) : null;
+  );
 };

--- a/packages/web/src/components/PokemonDetails/SpriteView.tsx
+++ b/packages/web/src/components/PokemonDetails/SpriteView.tsx
@@ -78,7 +78,7 @@ export const SpriteView = () => {
       <CardMedia
         className={styles.media}
         image={getSprite() || undefined}
-        title={pokemon.name}
+        title={pokemon.name || ''}
       />
       <CardActions className={styles.cardActions}>
         {pokemon.sprites?.backDefault && (

--- a/packages/web/src/components/PokemonList/PokemonList.tsx
+++ b/packages/web/src/components/PokemonList/PokemonList.tsx
@@ -51,7 +51,7 @@ export const PokemonList = () => {
     return index === items.length ? (
       <Loading style={style} title="Loading more Pokémon…" padding={false} />
     ) : (
-      <PokemonListItem style={style} key={item?.name} pokemon={item} />
+      <PokemonListItem style={style} key={item?.id} pokemon={item} />
     );
   };
 

--- a/packages/web/src/components/PokemonList/PokemonListItem.tsx
+++ b/packages/web/src/components/PokemonList/PokemonListItem.tsx
@@ -14,7 +14,7 @@ import { PokemonNode } from '../../types';
 import { formatPokemonCaption } from '../../utils';
 
 export type PokemonListItemProps = {
-  pokemon?: Partial<PokemonNode>;
+  pokemon?: Partial<PokemonNode> | null;
   style: CSSProperties;
 };
 
@@ -26,6 +26,10 @@ export const PokemonListItem = memo(function ({
   const styles = useStyles();
 
   const setSelectedPokemon = useSetRecoilState(selectedPokemonState);
+
+  if (!pokemon) {
+    return null;
+  }
 
   const handleClick = () => setSelectedPokemon(pokemon);
 

--- a/packages/web/src/components/PokemonList/PokemonListItem.tsx
+++ b/packages/web/src/components/PokemonList/PokemonListItem.tsx
@@ -31,32 +31,32 @@ export const PokemonListItem = memo(function ({
     return null;
   }
 
-  const handleClick = () => setSelectedPokemon(pokemon);
+  const handleClick = () => {
+    setSelectedPokemon(pokemon);
+  };
 
   return (
-    <>
-      <ListItem
-        alignItems="flex-start"
-        style={style}
-        button
-        onClick={handleClick}
-      >
-        <ListItemAvatar>
-          <Avatar
-            className={styles.avatar}
-            alt={pokemon?.name}
-            src={pokemon?.sprites?.frontDefault || ''}
-          />
-        </ListItemAvatar>
-        <ListItemText
-          primary={pokemon?.name}
-          secondary={formatPokemonCaption(pokemon)}
-          secondaryTypographyProps={{
-            variant: 'overline',
-          }}
+    <ListItem
+      alignItems="flex-start"
+      style={style}
+      button
+      onClick={handleClick}
+    >
+      <ListItemAvatar>
+        <Avatar
+          className={styles.avatar}
+          alt={pokemon?.name || ''}
+          src={pokemon?.sprites?.frontDefault || ''}
         />
-      </ListItem>
-    </>
+      </ListItemAvatar>
+      <ListItemText
+        primary={pokemon?.name}
+        secondary={formatPokemonCaption(pokemon)}
+        secondaryTypographyProps={{
+          variant: 'overline',
+        }}
+      />
+    </ListItem>
   );
 });
 

--- a/packages/web/src/operations/GetPokemon.graphql
+++ b/packages/web/src/operations/GetPokemon.graphql
@@ -1,6 +1,7 @@
 query GetPokemon($id: ID!) {
   getPokemon(id: $id) {
     id
+    pokedexNumber
     name
     baseExperience
     height
@@ -17,12 +18,15 @@ query GetPokemon($id: ID!) {
       frontShinyFemale
     }
     abilities {
+      id
       name
     }
     heldItems {
+      id
       name
     }
     moves {
+      id
       name
     }
     species {
@@ -36,10 +40,12 @@ query GetPokemon($id: ID!) {
       }
     }
     stats {
+      id
       name
       baseStat
     }
     types {
+      id
       name
     }
   }

--- a/packages/web/src/operations/ListPokemon.graphql
+++ b/packages/web/src/operations/ListPokemon.graphql
@@ -9,6 +9,7 @@ query ListPokemon(
       cursor
       node {
         id
+        pokedexNumber
         name
         baseExperience
         order
@@ -16,6 +17,7 @@ query ListPokemon(
           frontDefault
         }
         types {
+          id
           name
         }
       }

--- a/packages/web/src/utils/string.ts
+++ b/packages/web/src/utils/string.ts
@@ -8,7 +8,7 @@ export const formatPokemonCaption = (
     return '';
   }
   const types = pokemon?.types?.map((type) => type?.name);
-  return `${pokemon?.id} • ${types?.join('/')}`;
+  return `${pokemon?.pokedexNumber} • ${types?.join('/')}`;
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -5011,15 +5011,6 @@ apollo-reporting-protobuf@^0.7.0:
   dependencies:
     "@apollo/protobufjs" "1.2.2"
 
-apollo-server-cache-memcached@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/apollo-server-cache-memcached/-/apollo-server-cache-memcached-0.8.0.tgz#b84b07fb79a03a302a564df2cd3df1fc79f3c8ea"
-  integrity sha512-PMtZK2BSZ0iZnndIFLfuvSwIGoMZFl1U+a40Z5OuG6d9iMfF2pc34zowIiIXN2ghBTUYeXHTVqwZZXqktjoRMg==
-  dependencies:
-    apollo-server-caching "^0.7.0"
-    apollo-server-env "^3.1.0"
-    memcached "^2.2.2"
-
 apollo-server-caching@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz#e6d1e68e3bb571cba63a61f60b434fb771c6ff39"
@@ -5113,15 +5104,6 @@ apollo-server-plugin-base@^0.12.0:
   integrity sha512-jnNIztYz34ImE7off0t9LwseGCR/J0H1wlbiBGvdXvQY+ZiMfVF2oF8KdSAPxG2vT6scvWP4GFS/FsZcOyP1Xw==
   dependencies:
     apollo-server-types "^0.8.0"
-
-apollo-server-plugin-response-cache@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/apollo-server-plugin-response-cache/-/apollo-server-plugin-response-cache-0.8.0.tgz#401123f4c397a31a19be20caa9a4d06ebc47480f"
-  integrity sha512-MkyJt0yDvM7e4MSLxb10dSsqaAX5Xj4PUWiINEtiW8LRkg3R2ZocV/Z2dZeMOZcq1+pkQNTTe2x8Eavr/Ihs5A==
-  dependencies:
-    apollo-cache-control "^0.13.0"
-    apollo-server-caching "^0.7.0"
-    apollo-server-plugin-base "^0.12.0"
 
 apollo-server-testing@^2.24.0:
   version "2.24.0"
@@ -6848,11 +6830,6 @@ connect-history-api-fallback@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
   integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
-
-connection-parse@0.0.x:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/connection-parse/-/connection-parse-0.0.7.tgz#18e7318aab06a699267372b10c5226d25a1c9a69"
-  integrity sha1-GOcxiqsGppkmc3KxDFIm0locmmk=
 
 console-browserify@^1.1.0:
   version "1.2.0"
@@ -9781,14 +9758,6 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
-hashring@3.2.x:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/hashring/-/hashring-3.2.0.tgz#fda4efde8aa22cdb97fb1d2a65e88401e1c144ce"
-  integrity sha1-/aTv3oqiLNuX+x0qZeiEAeHBRM4=
-  dependencies:
-    connection-parse "0.0.x"
-    simple-lru-cache "0.0.x"
-
 he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -10917,13 +10886,6 @@ iterall@^1.1.3, iterall@^1.2.1, iterall@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
-
-jackpot@>=0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/jackpot/-/jackpot-0.0.6.tgz#3cff064285cbf66f4eab2593c90bce816a821849"
-  integrity sha1-PP8GQoXL9m9OqyWTyQvOgWqCGEk=
-  dependencies:
-    retry "0.6.0"
 
 java-invoke-local@0.0.6:
   version "0.0.6"
@@ -12350,14 +12312,6 @@ mem@^6.0.1:
   dependencies:
     map-age-cleaner "^0.1.3"
     mimic-fn "^3.0.0"
-
-memcached@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/memcached/-/memcached-2.2.2.tgz#68f86ccfd84bcf93cc25ed46d6d7fc0c7521c9d5"
-  integrity sha1-aPhsz9hLz5PMJe1G1tf8DHUhydU=
-  dependencies:
-    hashring "3.2.x"
-    jackpot ">=0.0.6"
 
 "memoize-one@>=3.1.1 <6":
   version "5.2.1"
@@ -15726,11 +15680,6 @@ retry@0.12.0, retry@^0.12.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
-retry@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.6.0.tgz#1c010713279a6fd1e8def28af0c3ff1871caa537"
-  integrity sha1-HAEHEyeab9Ho3vKK8MP/GHHKpTc=
-
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -16255,11 +16204,6 @@ signedsource@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
   integrity sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo=
-
-simple-lru-cache@0.0.x:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz#d59cc3a193c1a5d0320f84ee732f6e4713e511dd"
-  integrity sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0=
 
 simple-swizzle@^0.2.2:
   version "0.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5011,6 +5011,15 @@ apollo-reporting-protobuf@^0.7.0:
   dependencies:
     "@apollo/protobufjs" "1.2.2"
 
+apollo-server-cache-memcached@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-cache-memcached/-/apollo-server-cache-memcached-0.8.0.tgz#b84b07fb79a03a302a564df2cd3df1fc79f3c8ea"
+  integrity sha512-PMtZK2BSZ0iZnndIFLfuvSwIGoMZFl1U+a40Z5OuG6d9iMfF2pc34zowIiIXN2ghBTUYeXHTVqwZZXqktjoRMg==
+  dependencies:
+    apollo-server-caching "^0.7.0"
+    apollo-server-env "^3.1.0"
+    memcached "^2.2.2"
+
 apollo-server-caching@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/apollo-server-caching/-/apollo-server-caching-0.7.0.tgz#e6d1e68e3bb571cba63a61f60b434fb771c6ff39"
@@ -5104,6 +5113,15 @@ apollo-server-plugin-base@^0.12.0:
   integrity sha512-jnNIztYz34ImE7off0t9LwseGCR/J0H1wlbiBGvdXvQY+ZiMfVF2oF8KdSAPxG2vT6scvWP4GFS/FsZcOyP1Xw==
   dependencies:
     apollo-server-types "^0.8.0"
+
+apollo-server-plugin-response-cache@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-plugin-response-cache/-/apollo-server-plugin-response-cache-0.8.0.tgz#401123f4c397a31a19be20caa9a4d06ebc47480f"
+  integrity sha512-MkyJt0yDvM7e4MSLxb10dSsqaAX5Xj4PUWiINEtiW8LRkg3R2ZocV/Z2dZeMOZcq1+pkQNTTe2x8Eavr/Ihs5A==
+  dependencies:
+    apollo-cache-control "^0.13.0"
+    apollo-server-caching "^0.7.0"
+    apollo-server-plugin-base "^0.12.0"
 
 apollo-server-testing@^2.24.0:
   version "2.24.0"
@@ -6830,6 +6848,11 @@ connect-history-api-fallback@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
   integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
+
+connection-parse@0.0.x:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/connection-parse/-/connection-parse-0.0.7.tgz#18e7318aab06a699267372b10c5226d25a1c9a69"
+  integrity sha1-GOcxiqsGppkmc3KxDFIm0locmmk=
 
 console-browserify@^1.1.0:
   version "1.2.0"
@@ -9758,6 +9781,14 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+hashring@3.2.x:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/hashring/-/hashring-3.2.0.tgz#fda4efde8aa22cdb97fb1d2a65e88401e1c144ce"
+  integrity sha1-/aTv3oqiLNuX+x0qZeiEAeHBRM4=
+  dependencies:
+    connection-parse "0.0.x"
+    simple-lru-cache "0.0.x"
+
 he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
@@ -10886,6 +10917,13 @@ iterall@^1.1.3, iterall@^1.2.1, iterall@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
+
+jackpot@>=0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/jackpot/-/jackpot-0.0.6.tgz#3cff064285cbf66f4eab2593c90bce816a821849"
+  integrity sha1-PP8GQoXL9m9OqyWTyQvOgWqCGEk=
+  dependencies:
+    retry "0.6.0"
 
 java-invoke-local@0.0.6:
   version "0.0.6"
@@ -12312,6 +12350,14 @@ mem@^6.0.1:
   dependencies:
     map-age-cleaner "^0.1.3"
     mimic-fn "^3.0.0"
+
+memcached@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/memcached/-/memcached-2.2.2.tgz#68f86ccfd84bcf93cc25ed46d6d7fc0c7521c9d5"
+  integrity sha1-aPhsz9hLz5PMJe1G1tf8DHUhydU=
+  dependencies:
+    hashring "3.2.x"
+    jackpot ">=0.0.6"
 
 "memoize-one@>=3.1.1 <6":
   version "5.2.1"
@@ -15680,6 +15726,11 @@ retry@0.12.0, retry@^0.12.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
   integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
 
+retry@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.6.0.tgz#1c010713279a6fd1e8def28af0c3ff1871caa537"
+  integrity sha1-HAEHEyeab9Ho3vKK8MP/GHHKpTc=
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -16205,6 +16256,11 @@ signedsource@^1.0.0:
   resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
   integrity sha1-HdrOSYF5j5O9gzlzgD2A1S6TrWo=
 
+simple-lru-cache@0.0.x:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz#d59cc3a193c1a5d0320f84ee732f6e4713e511dd"
+  integrity sha1-1ZzDoZPBpdAyD4Tucy9uRxPlEd0=
+
 simple-swizzle@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
@@ -16572,11 +16628,6 @@ start-server-nestjs-webpack-plugin@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/start-server-nestjs-webpack-plugin/-/start-server-nestjs-webpack-plugin-2.2.5.tgz#4828f7fe964c275c9479d6a3aa0c31c52c8e2665"
   integrity sha512-tnuGcGbT7qSF5h08/T7YkP6rX/m3DcsC+s8srzD7LNC7WIR7p/FU1+iZqfNUHAtjSFdAG0thK2H3by2AY1kr6w==
-
-start-server-webpack-plugin@^2.2.5:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/start-server-webpack-plugin/-/start-server-webpack-plugin-2.2.5.tgz#4a2838759b0f36acd11b0b2f5f196f289ae29d31"
-  integrity sha512-DRCkciwCJoCFZ+wt3wWMkR1M2mpVhJbUKFXqhK3FWyIUKYb42NnocH5sMwqgo+nPNHupqNwK/v8lgfBbr2NKdg==
 
 static-extend@^0.1.1:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1380,6 +1380,11 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@discoveryjs/json-ext@^0.5.0":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz#8f03a22a04de437254e8ce8cc84ba39689288752"
+  integrity sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==
+
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
@@ -3552,7 +3557,7 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/recommended/-/recommended-1.0.1.tgz#7619bad397e06ead1c5182926c944e0ca6177f52"
   integrity sha512-2xN+iGTbPBEzGSnVp/Hd64vKJCJWxsi9gfs88x4PPMyEjHJoA3o5BY9r5OLPHIZU2pAQxkSAsJFqn6itClP8mQ==
 
-"@types/accepts@*":
+"@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
   integrity sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==
@@ -3612,7 +3617,7 @@
   resolved "https://registry.yarnpkg.com/@types/base64-url/-/base64-url-2.2.0.tgz#ff17c19bf357821bd637af2f54f7922443377950"
   integrity sha512-adGV3KUTc9uO7kZNQOF3u9WVuKZsgKPsaShZePe+hQXNYd+3dnIK+Y2Wyw7A6M4iIH01xKCRZCZWLQnG9bulIQ==
 
-"@types/body-parser@*":
+"@types/body-parser@*", "@types/body-parser@1.19.0":
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.0.tgz#0685b3c47eb3006ffed117cdd55164b61f80538f"
   integrity sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==
@@ -3641,6 +3646,11 @@
     "@types/express" "*"
     "@types/keygrip" "*"
     "@types/node" "*"
+
+"@types/cors@2.8.10":
+  version "2.8.10"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.10.tgz#61cc8469849e5bcdd0c7044122265c39cec10cf4"
+  integrity sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==
 
 "@types/d3-array@*":
   version "2.9.0"
@@ -3883,7 +3893,7 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/express-serve-static-core@^4.17.18":
+"@types/express-serve-static-core@4.17.19", "@types/express-serve-static-core@^4.17.18":
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz#00acfc1632e729acac4f1530e9e16f6dd1508a1d"
   integrity sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==
@@ -3892,7 +3902,7 @@
     "@types/qs" "*"
     "@types/range-parser" "*"
 
-"@types/express@*":
+"@types/express@*", "@types/express@4.17.11":
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.11.tgz#debe3caa6f8e5fcda96b47bd54e2f40c4ee59545"
   integrity sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==
@@ -4653,6 +4663,23 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@webpack-cli/configtest@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.0.3.tgz#204bcff87cda3ea4810881f7ea96e5f5321b87b9"
+  integrity sha512-WQs0ep98FXX2XBAfQpRbY0Ma6ADw8JR6xoIkaIiJIzClGOMqVRvPCWqndTxf28DgFopWan0EKtHtg/5W1h0Zkw==
+
+"@webpack-cli/info@^1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.2.4.tgz#7381fd41c9577b2d8f6c2594fad397ef49ad5573"
+  integrity sha512-ogE2T4+pLhTTPS/8MM3IjHn0IYplKM4HbVNMCWA9N4NrdPzunwenpCsqKEXyejMfRu6K8mhauIPYf8ZxWG5O6g==
+  dependencies:
+    envinfo "^7.7.3"
+
+"@webpack-cli/serve@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.4.0.tgz#f84fd07bcacefe56ce762925798871092f0f228e"
+  integrity sha512-xgT/HqJ+uLWGX+Mzufusl3cgjAcnqYYskaB7o0vRcwOEfuu6hMzSILQpnIzFMGsTaeaX4Nnekl+6fadLbl1/Vg==
+
 "@wry/context@^0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.6.0.tgz#f903eceb89d238ef7e8168ed30f4511f92d83e06"
@@ -4709,7 +4736,7 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
-accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
+accepts@^1.3.5, accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"
   integrity sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==
@@ -5036,6 +5063,29 @@ apollo-server-errors@^2.5.0:
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.5.0.tgz#5d1024117c7496a2979e3e34908b5685fe112b68"
   integrity sha512-lO5oTjgiC3vlVg2RKr3RiXIIQ5pGXBFxYGGUkKDhTud3jMIhs+gel8L8zsEjKaKxkjHhCQAA/bcEfYiKkGQIvA==
 
+apollo-server-express@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.24.0.tgz#f17444929fc776fa1c166d8bad9685bd65dfa1c9"
+  integrity sha512-wVoD53azxqVZt/i4yAm6cDDCXpbzr0AJpzOdNXVFW/KivInWEMF5ekCc80uMOawPeu78U7Skoc20akyvZKc+YA==
+  dependencies:
+    "@apollographql/graphql-playground-html" "1.6.27"
+    "@types/accepts" "^1.3.5"
+    "@types/body-parser" "1.19.0"
+    "@types/cors" "2.8.10"
+    "@types/express" "4.17.11"
+    "@types/express-serve-static-core" "4.17.19"
+    accepts "^1.3.5"
+    apollo-server-core "^2.24.0"
+    apollo-server-types "^0.8.0"
+    body-parser "^1.18.3"
+    cors "^2.8.5"
+    express "^4.17.1"
+    graphql-subscriptions "^1.0.0"
+    graphql-tools "^4.0.8"
+    parseurl "^1.3.2"
+    subscriptions-transport-ws "^0.9.16"
+    type-is "^1.6.16"
+
 apollo-server-lambda@^2.24.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/apollo-server-lambda/-/apollo-server-lambda-2.24.0.tgz#5584d871aa2cd88696153cb3a237bc96e83cf223"
@@ -5070,6 +5120,18 @@ apollo-server-types@^0.8.0:
     apollo-reporting-protobuf "^0.7.0"
     apollo-server-caching "^0.7.0"
     apollo-server-env "^3.1.0"
+
+apollo-server@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/apollo-server/-/apollo-server-2.24.0.tgz#68747b786af16803da0d0fa915334f4c81f312c4"
+  integrity sha512-KYYyBRLvqJaXFk64HfdgPilm8bqc2ON3hwhWmWx2Apsy4PC7paVK4gYFAUh9piPpeVZfF3t7zm+2J+9R47otjA==
+  dependencies:
+    apollo-server-core "^2.24.0"
+    apollo-server-express "^2.24.0"
+    express "^4.0.0"
+    graphql-subscriptions "^1.0.0"
+    graphql-tools "^4.0.8"
+    stoppable "^1.1.0"
 
 apollo-tracing@^0.14.0:
   version "0.14.0"
@@ -5775,7 +5837,7 @@ bn.js@^5.0.0, bn.js@^5.1.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
-body-parser@1.19.0:
+body-parser@1.19.0, body-parser@^1.18.3:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
@@ -6649,6 +6711,11 @@ commander@^5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
+commander@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
 common-tags@1.8.0, common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
@@ -6956,6 +7023,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cosmiconfig-toml-loader@1.0.0:
   version "1.0.0"
@@ -8052,7 +8127,7 @@ env-paths@^2.2.0:
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
-envinfo@^7.7.4:
+envinfo@^7.7.3, envinfo@^7.7.4:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.8.1.tgz#06377e3e5f4d379fea7ac592d5ad8927e0c4d475"
   integrity sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==
@@ -8601,7 +8676,7 @@ expect@^26.6.0, expect@^26.6.2:
     jest-message-util "^26.6.2"
     jest-regex-util "^26.0.0"
 
-express@^4.17.1:
+express@^4.0.0, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
@@ -8750,6 +8825,11 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
+fastest-levenshtein@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
+  integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
 
 fastq@^1.6.0:
   version "1.11.0"
@@ -9482,6 +9562,13 @@ graphql-request@^3.3.0:
     extract-files "^9.0.0"
     form-data "^3.0.0"
 
+graphql-subscriptions@^1.0.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/graphql-subscriptions/-/graphql-subscriptions-1.2.1.tgz#2142b2d729661ddf967b7388f7cf1dd4cf2e061d"
+  integrity sha512-95yD/tKi24q8xYa7Q9rhQN16AYj5wPbrb8tmHGM3WRc9EBmWrG/0kkMl+tQG8wcEuE9ibR4zyOM31p5Sdr2v4g==
+  dependencies:
+    iterall "^1.3.0"
+
 graphql-tag@^2.11.0, graphql-tag@^2.12.0:
   version "2.12.4"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.4.tgz#d34066688a4f09e72d6f4663c74211e9b4b7c4bf"
@@ -10199,6 +10286,11 @@ interpret@^1.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
+interpret@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
+  integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
+
 ip-regex@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"
@@ -10790,7 +10882,7 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-iterall@^1.1.3, iterall@^1.2.1:
+iterall@^1.1.3, iterall@^1.2.1, iterall@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
@@ -13031,7 +13123,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -13552,7 +13644,7 @@ parse5@6.0.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
 
-parseurl@~1.3.2, parseurl@~1.3.3:
+parseurl@^1.3.2, parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
@@ -15191,6 +15283,13 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
+rechoir@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.7.0.tgz#32650fd52c21ab252aa5d65b19310441c7e03aca"
+  integrity sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==
+  dependencies:
+    resolve "^1.9.0"
+
 recoil@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.2.0.tgz#69344b5bec3129272560d8d9d6001ada3ee4d80c"
@@ -15524,7 +15623,7 @@ resolve@1.18.1:
     is-core-module "^2.0.0"
     path-parse "^1.0.6"
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.8.1, resolve@^1.9.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -16469,6 +16568,16 @@ start-server-and-test@^1.12.1:
     ps-tree "1.2.0"
     wait-on "5.3.0"
 
+start-server-nestjs-webpack-plugin@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/start-server-nestjs-webpack-plugin/-/start-server-nestjs-webpack-plugin-2.2.5.tgz#4828f7fe964c275c9479d6a3aa0c31c52c8e2665"
+  integrity sha512-tnuGcGbT7qSF5h08/T7YkP6rX/m3DcsC+s8srzD7LNC7WIR7p/FU1+iZqfNUHAtjSFdAG0thK2H3by2AY1kr6w==
+
+start-server-webpack-plugin@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/start-server-webpack-plugin/-/start-server-webpack-plugin-2.2.5.tgz#4a2838759b0f36acd11b0b2f5f196f289ae29d31"
+  integrity sha512-DRCkciwCJoCFZ+wt3wWMkR1M2mpVhJbUKFXqhK3FWyIUKYb42NnocH5sMwqgo+nPNHupqNwK/v8lgfBbr2NKdg==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -16486,6 +16595,11 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+stoppable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stoppable/-/stoppable-1.1.0.tgz#32da568e83ea488b08e4d7ea2c3bcc9d75015d5b"
+  integrity sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==
 
 stream-browserify@^2.0.1:
   version "2.0.2"
@@ -16759,7 +16873,7 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
-subscriptions-transport-ws@^0.9.11:
+subscriptions-transport-ws@^0.9.11, subscriptions-transport-ws@^0.9.16:
   version "0.9.18"
   resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.18.tgz#bcf02320c911fbadb054f7f928e51c6041a37b97"
   integrity sha512-tztzcBTNoEbuErsVQpTN2xUNN/efAZXyCyL5m3x4t6SKrEiTL2N8SaKWBFWM4u56pL79ULif3zjyeq+oV+nOaA==
@@ -17364,7 +17478,7 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-type-is@~1.6.17, type-is@~1.6.18:
+type-is@^1.6.16, type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
   integrity sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==
@@ -17731,7 +17845,7 @@ uuid@^8.0.0, uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-v8-compile-cache@^2.0.3:
+v8-compile-cache@^2.0.3, v8-compile-cache@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
@@ -17770,7 +17884,7 @@ value-or-promise@~1.0.5:
   resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.6.tgz#218aa4794aa2ee24dcf48a29aba4413ed584747f"
   integrity sha512-9r0wQsWD8z/BxPOvnwbPf05ZvFngXyouE9EKB+5GbYix+BYnAwrIChCUyFIinfbf2FL/U71z+CPpbnmTdxrwBg==
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
@@ -17886,6 +18000,25 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
+webpack-cli@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.7.0.tgz#3195a777f1f802ecda732f6c95d24c0004bc5a35"
+  integrity sha512-7bKr9182/sGfjFm+xdZSwgQuFjgEcy0iCTIBxRUeteJ2Kr8/Wz0qNJX+jw60LU36jApt4nmMkep6+W5AKhok6g==
+  dependencies:
+    "@discoveryjs/json-ext" "^0.5.0"
+    "@webpack-cli/configtest" "^1.0.3"
+    "@webpack-cli/info" "^1.2.4"
+    "@webpack-cli/serve" "^1.4.0"
+    colorette "^1.2.1"
+    commander "^7.0.0"
+    execa "^5.0.0"
+    fastest-levenshtein "^1.0.12"
+    import-local "^3.0.2"
+    interpret "^2.2.0"
+    rechoir "^0.7.0"
+    v8-compile-cache "^2.2.0"
+    webpack-merge "^5.7.3"
+
 webpack-dev-middleware@^3.7.2:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.7.3.tgz#0639372b143262e2b84ab95d3b91a7597061c2c5"
@@ -17953,6 +18086,14 @@ webpack-manifest-plugin@2.2.0:
     lodash ">=3.5 <5"
     object.entries "^1.1.0"
     tapable "^1.0.0"
+
+webpack-merge@^5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.7.3.tgz#2a0754e1877a25a8bbab3d2475ca70a052708213"
+  integrity sha512-6/JUQv0ELQ1igjGDzHkXbVDRxkfA57Zw7PfiupdLFJYrgFqY5ZP8xxbpp2lU3EPwYx89ht5Z/aDkD40hFCm5AA==
+  dependencies:
+    clone-deep "^4.0.1"
+    wildcard "^2.0.0"
 
 webpack-sources@^1.1.0, webpack-sources@^1.3.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
@@ -18111,6 +18252,11 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
+
+wildcard@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
+  integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
This demonstrates how we can use a server with in-memory caching to speed up requests.

[Apollo handles caching for RESTDataSource by default.](https://www.apollographql.com/docs/apollo-server/data/data-sources/#caching)

- Add `start-server` script to start Node server with in-memory caching for REST calls.
- Move `getPokemon` REST call in `listPokemon` to `pokemonNode` field resolver.
- Use `name` as `id` since it is included in [NamedAPIResource](https://pokeapi.co/docs/v2#namedapiresource).
- Add `pokedexNumber` to store previous `id` and update usages.